### PR TITLE
Use semantic line breaks

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -38,35 +38,36 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 
 <p>
 <dfn>Transitional</dfn> metadata is added to the specification with the
-intention of removing it in the future. Implementations may be expected (MUST) or
-encouraged (SHOULD) to support the reading of the data, but writing will usually
-be optional (MAY). Examples of transitional metadata include custom additions by
-implementations that are later submitted as a formal specification. (See [[#bf2raw]])
+intention of removing it in the future.
+Implementations may be expected (MUST) or encouraged (SHOULD) to support the reading of the data,
+but writing will usually be optional (MAY).
+Examples of transitional metadata include custom additions by implementations
+that are later submitted as a formal specification. (See [[#bf2raw]])
 </p>
 
-Some of the JSON examples in this document include comments. However, these are only for
-clarity purposes and comments MUST NOT be included in JSON objects.
+Some of the JSON examples in this document include comments.
+However, these are only for clarity purposes and comments MUST NOT be included in JSON objects.
 
 Storage format {#storage-format}
 ================================
 
 OME-Zarr is implemented using the Zarr format as defined by the
 [version 3 of the Zarr specification](https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html).
-All features of the Zarr format including codecs, chunk grids, chunk 
-key encodings, data types and storage transformers may be used with 
-OME-Zarr unless explicitly disallowed in this specification.
+All features of the Zarr format including
+codecs, chunk grids, chunk key encodings, data types and storage transformers
+may be used with OME-Zarr unless explicitly disallowed in this specification.
 
 An overview of the layout of an OME-Zarr fileset should make
-understanding the following metadata sections easier. The hierarchy
-is represented here as it would appear locally but could equally
+understanding the following metadata sections easier.
+The hierarchy is represented here as it would appear locally but could equally
 be stored on a web server to be accessed via HTTP or in object storage
 like S3 or GCS.
 
 Images {#image-layout}
 ----------------------
 
-The following layout describes the expected Zarr hierarchy for images with
-multiple levels of resolutions and optionally associated labels.
+The following layout describes the expected Zarr hierarchy
+for images with multiple levels of resolutions and optionally associated labels.
 Note that the number of dimensions is variable between 2 and 5 and that axis names are arbitrary, see [[#multiscale-md]] for details.
 
 <pre>
@@ -115,7 +116,8 @@ High-content screening {#hcs-layout}
 ------------------------------------
 
 The following specification defines the hierarchy for a high-content screening
-dataset. Three groups MUST be defined above the images:
+dataset.
+Three groups MUST be defined above the images:
 
 -   the group above the images defines the well and MUST implement the
     [well specification](#well-md). All images contained in a well are fields
@@ -154,11 +156,11 @@ A well group SHOULD NOT be present if there are no images in the well.
 OME-Zarr Metadata {#metadata}
 =============================
 
-The "OME-Zarr Metadata" contains metadata keys as specified below 
-for discovering certain types of data, especially images.
+The "OME-Zarr Metadata" contains metadata keys as specified below for discovering certain types of data,
+especially images.
 
-The OME-Zarr Metadata is stored in the various `zarr.json` files throughout the above array
-hierarchy. In this file, the metadata is stored under the namespaced key 
+The OME-Zarr Metadata is stored in the various `zarr.json` files throughout the above array hierarchy. 
+In this file, the metadata is stored under the namespaced key 
 `ome` in `attributes`.
 The version of the OME-Zarr Metadata is denoted as a string in the `version` attribute within the `ome` namespace.
 
@@ -179,8 +181,8 @@ The OME-Zarr Metadata version MUST be consistent within a hierarchy.
 "axes" metadata {#axes-md}
 --------------------------
 
-"axes" describes the dimensions of a coordinate systems and adds an interpretation to the data along that dimension. A named collection
-of axes forms a coordinate system ([[#coord-sys-md]]) (see below).
+"axes" describes the dimensions of a coordinate systems and adds an interpretation to the data along that dimension.
+A named collection of axes forms a coordinate system ([[#coord-sys-md]]) (see below).
 It is a list of dictionaries, where each dictionary describes a dimension (axis) and:
 - MUST contain the field "name" that gives the name for this dimension. The values MUST be unique across all "name" fields.
 - SHOULD contain the field "type". It SHOULD be one of the strings "array", "space", "time", "channel", "coordinate", or
@@ -211,12 +213,13 @@ Examples of valid axes:
 ```
 </div>
 
-Arrays are inherently discrete (see Array coordinate systems, below) but are often used to store discrete samples of a
-continuous variable. The continuous values "in between" discrete samples can be retrieved using an *interpolation* method. If an
-axis is continuous (`"discrete" : false`), it indicates that interpolation is well-defined. Axes representing `space` and `time`
-are usually continuous. Similarly, joint interpolation across axes is well-defined only for axes of the same `type`. In
-contrast, discrete axes (`"discrete" : true`) may be indexed only by integers.  Axes of representing a `channel`, `coordinate`,
-or `displacement` are usually discrete.
+Arrays are inherently discrete (see Array coordinate systems, below) but are often used to store discrete samples of a continuous variable.
+The continuous values "in between" discrete samples can be retrieved using an *interpolation* method.
+If an axis is continuous (`"discrete" : false`), it indicates that interpolation is well-defined.
+Axes representing `space` and `time` are usually continuous.
+Similarly, joint interpolation across axes is well-defined only for axes of the same `type`.
+In contrast, discrete axes (`"discrete" : true`) may be indexed only by integers.
+Axes of representing a `channel`, `coordinate`, or `displacement` are usually discrete.
 
 Note: The most common methods for interpolation are "nearest neighbor", "linear", "cubic", and "windowed sinc". Here, we refer
 to any method that obtains values at real valued coordinates using discrete samples as an "interpolator". As such, label images
@@ -238,15 +241,17 @@ For the coordinate system:
 }
 ```
 
-Indexing an image at the point `(0.1, 0.2, 0.3, 0.4)` is not valid, because the value of the first coordinate (`0.1`) refers
-to the discrete axis `"c"`.  Indexing an image at the point `(1, 0.2, 0.3, 0.4)` is valid.
+Indexing an image at the point `(0.1, 0.2, 0.3, 0.4)` is not valid,
+because the value of the first coordinate (`0.1`) refers to the discrete axis `"c"`.
+Indexing an image at the point `(1, 0.2, 0.3, 0.4)` is valid.
 </div>
 
 
 "coordinateSystems" metadata {#coord-sys-md}
 --------------------------
 
-A "coordinate system" is a collection of "axes" / dimensions with a name. Every coordinate system:
+A "coordinate system" is a collection of "axes" / dimensions with a name.
+Every coordinate system:
 - MUST contain the field "name". The value MUST be a non-empty string that is unique among `coordinateSystem`s.
 - MUST contain the field "axes", whose value is an array of valid "axes".
 
@@ -264,32 +269,38 @@ A "coordinate system" is a collection of "axes" / dimensions with a name. Every 
 ```
 </div>
 
-The order of the `"axes"` list matters and defines the index of each array dimension and coordinates for points in that
-coordinate system. For the above example, the `"x"` dimension is the last dimension. The "dimensionality" of a coordinate system
-is indicated by the length of its "axes" array. The "volume_micrometers" example coordinate system above is three dimensional (3D).
+The order of the `"axes"` list matters and defines the index of each array dimension and coordinates for points in that coordinate system.
+For the above example, the `"x"` dimension is the last dimension.
+The "dimensionality" of a coordinate system is indicated by the length of its "axes" array.
+The "volume_micrometers" example coordinate system above is three dimensional (3D).
 
 The axes of a coordinate system (see below) give information about the types, units, and other properties of the coordinate
-system's dimensions. Axis `name`s may contain semantically meaningful information, but can be arbitrary. As a result, two
-coordinate systems that have identical axes in the same order may not be "the same" in the sense that measurements at the same
-point refer to different physical entities and therefore should not be analyzed jointly. Tasks that require images, annotations,
-regions of interest, etc., SHOULD ensure that they are in the same coordinate system (same name, with identical axes) or can be
-transformed to the same coordinate system before doing analysis. See the example below.
+system's dimensions.
+Axis `name`s may contain semantically meaningful information, but can be arbitrary.
+As a result, two coordinate systems that have identical axes in the same order may not be "the same"
+in the sense that measurements at the same point refer to different physical entities and therefore should not be analyzed jointly.
+Tasks that require images, annotations, regions of interest, etc., 
+SHOULD ensure that they are in the same coordinate system (same name, with identical axes)
+or can be transformed to the same coordinate system before doing analysis. See the example below.
 
 <div class=example>
 
-Two instruments simultaneously image the same sample from two different angles, and the 3D data from both instruments are
-calibrated to "micrometer" units. Two samples are collected ("sampleA" and "sampleB"). An analysis of sample A requires
-measurements from both instruments' images at certain points in space. Suppose a region of interest (ROI) is determined from the
-image obtained from instrument 2, but quantification from that region is needed for instrument 1. Since measurements were
-collected at different angles, a measurement by instrument 1 at the point with coordinates (x,y,z) may not correspond to the
-measurement at the same point in instrument 2 (i.e., it may not be the same physical location in the sample). To analyze both
-images together, they must be in the same coordinate system.
+Two instruments simultaneously image the same sample from two different angles,
+and the 3D data from both instruments are calibrated to "micrometer" units.
+Two samples are collected ("sampleA" and "sampleB").
+An analysis of sample A requires measurements from both instruments' images at certain points in space.
+Suppose a region of interest (ROI) is determined from the image obtained from instrument 2,
+but quantification from that region is needed for instrument 1.
+Since measurements were collected at different angles, 
+a measurement by instrument 1 at the point with coordinates (x,y,z) 
+may not correspond to the measurement at the same point in instrument 2 (i.e., it may not be the same physical location in the sample). 
+To analyze both images together, they must be in the same coordinate system.
 
-The set of coordinate transformations ([[#trafo-md]]) encodes relationships between coordinate systems, specifically, how to
-convert points and images to different coordinate systems.  Implementations can apply the coordinate transform to images or
-points in coordinate system "sampleA_instrument2" to bring them into the "sampleA_instrument1" coordinate system. In this case,
-the ROI should be transformed to the "sampleA_image1" coordinate system, then used for quantification with the instrument 1
-image.
+The set of coordinate transformations ([[#trafo-md]]) encodes relationships between coordinate systems, 
+specifically, how to convert points and images to different coordinate systems.
+Implementations can apply the coordinate transform to images or points in coordinate system "sampleA_instrument2" to bring them into the "sampleA_instrument1" coordinate system.
+In this case, the ROI should be transformed to the "sampleA_image1" coordinate system,
+then used for quantification with the instrument 1 image.
 
 ```json
 "coordinateSystems" : [
@@ -325,14 +336,16 @@ image.
 
 ### Array coordinate systems
 
-The dimensions of an array do not have an interpretation until they are associated with a coordinate system via a coordinate
-transformation. Nevertheless, it can be useful to refer to the "raw" coordinates of the array. Some applications might prefer to
-define points or regions-of-interest in "pixel coordinates" rather than "physical coordinates," for example. Indicating that
-choice explicitly will be important for interoperability. This is possible by using **array coordinate systems**.
+The dimensions of an array do not have an interpretation 
+until they are associated with a coordinate system via a coordinate transformation.
+Nevertheless, it can be useful to refer to the "raw" coordinates of the array.
+Some applications might prefer to define points or regions-of-interest in "pixel coordinates" rather than "physical coordinates", for example.
+Indicating that choice explicitly will be important for interoperability.
+This is possible by using **array coordinate systems**.
 
-Every array has a default coordinate system whose parameters need not be explicitly defined. Its name is the path to the array
-in the container, its axes have `"type":"array"`, are unitless, and have default "name"s. The ith axis has `"name":"dim_i"`
-(these are the same default names used by [xarray](https://docs.xarray.dev/en/stable/user-guide/terminology.html)).
+Every array has a default coordinate system whose parameters need not be explicitly defined.
+Its name is the path to the array in the container, its axes have `"type":"array"`, are unitless, and have default "name"s.
+The ith axis has `"name":"dim_i"` (these are the same default names used by [xarray](https://docs.xarray.dev/en/stable/user-guide/terminology.html)).
 <div class=example>
 For example, a 3D array at path `0` defines the coordinate system:
 
@@ -351,10 +364,11 @@ though this object should not and need not explicitly appear in metadata.
 </div>
 
 
-The dimensionality of each array coordinate system equals the dimensionality of its corresponding zarr array.  The axis with
-name `"dim_i"` is the ith element of the `"axes"` list. The axes and their order align with the `shape`
-attribute in the zarr array attributes, and whose data depends on the byte order used to store
-chunks. As described in the [zarr array metadata](https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#array-metadata),
+The dimensionality of each array coordinate system equals the dimensionality of its corresponding zarr array.
+The axis with name `"dim_i"` is the ith element of the `"axes"` list.
+The axes and their order align with the `shape` attribute in the zarr array attributes,
+and whose data depends on the byte order used to store chunks.
+As described in the [zarr array metadata](https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#array-metadata),
 the last dimension of an array in "C" order are stored contiguously on disk or in-memory when directly loaded. 
 
 <div class=example>
@@ -373,10 +387,10 @@ For example, if `0/zarr.json` contains:
 Then `dim_0` has length 4, `dim_1` has length 3, and `dim_2` has length 5.
 </div>
 
-The name and axes names MAY be customized by including a `arrayCoordinateSystem` field in
-the user-defined attributes of the array whose value is a coordinate system object. The length of
-`axes` MUST be equal to the dimensionality. The value of `"type"` for each object in the 
-axes array MUST equal `"array"`.
+The name and axes names MAY be customized by including a `arrayCoordinateSystem` field
+in the user-defined attributes of the array whose value is a coordinate system object.
+The length of `axes` MUST be equal to the dimensionality.
+The value of `"type"` for each object in the axes array MUST equal `"array"`.
 
 <div class=example>
 
@@ -394,12 +408,13 @@ Note that dimension `i` is contiguous in memory.
 
 **The pixel/voxel center is the origin of the continuous coordinate system.**
 
-It is vital to consistently define relationship between the discrete/array and continuous/interpolated
-coordinate systems. A pixel/voxel is the continuous region (rectangle) that corresponds to a single sample
-in the discrete array, i.e., the area corresponding to nearest-neighbor (NN) interpolation of that sample.
-The center of a 2d pixel corresponding to the origin `(0,0)` in the discrete array is the origin of the continuous coordinate
-system `(0.0, 0.0)` (when the transformation is the identity). The continuous rectangle of the pixel is given by the
-half-open interval `[-0.5, 0.5) x [-0.5, 0.5)` (i.e., -0.5 is included, +0.5 is excluded). See chapter 4 and figure 4.1 of the ITK Software Guide [[itk]].
+It is vital to consistently define relationship between the discrete/array and continuous/interpolated coordinate systems.
+A pixel/voxel is the continuous region (rectangle) that corresponds to a single sample in the discrete array,
+i.e., the area corresponding to nearest-neighbor (NN) interpolation of that sample.
+The center of a 2d pixel corresponding to the origin `(0,0)` in the discrete array
+is the origin of the continuous coordinate system `(0.0, 0.0)` (when the transformation is the identity).
+The continuous rectangle of the pixel is given by the half-open interval 
+`[-0.5, 0.5) x [-0.5, 0.5)` (i.e., -0.5 is included, +0.5 is excluded). See chapter 4 and figure 4.1 of the ITK Software Guide [[itk]].
 
 
 
@@ -487,8 +502,8 @@ Conforming readers:
 
 "coordinateTransformations" describe the mapping between two coordinate systems (defined by "axes").
 For example, to map an array's discrete coordinate system to its corresponding physical coordinates.
-Coordinate transforms are in the "forward" direction. They represent functions from *points* in the
-input space to *points* in the output space. 
+Coordinate transforms are in the "forward" direction.
+They represent functions from *points* in the input space to *points* in the output space. 
 
 
 - MUST contain the field "type".
@@ -553,8 +568,9 @@ Conforming readers:
 - SHOULD be able to apply transformations to images;
 
 Coordinate transformations from array to physical coordinates MUST be stored in multiscales ([[#multiscale-md]]). 
-Transformations between different images MUST be stored in the attributes of a parent zarr group. For transformations that store
-data or parameters in a zarr array, those zarr arrays SHOULD be stored in a zarr group `"coordinateTransformations"`.
+Transformations between different images MUST be stored in the attributes of a parent zarr group.
+For transformations that store data or parameters in a zarr array,
+those zarr arrays SHOULD be stored in a zarr group `"coordinateTransformations"`.
 
 <pre>
 store.zarr                      # Root folder of the zarr store
@@ -583,17 +599,16 @@ store.zarr                      # Root folder of the zarr store
 
 ### Additional details
 
-Most coordinate transformations MUST specify their input and output coordinate systems using `input` and `output` with a string value
-corresponding to the name of a coordinate system. The coordinate system's name may be the path to an array, and therefore may
-not appear in the list of coordinate systems.
+Most coordinate transformations MUST specify their input and output coordinate systems using `input` and `output` with a string value corresponding to the name of a coordinate system.
+The coordinate system's name may be the path to an array, and therefore may not appear in the list of coordinate systems.
 
-Exceptions are if the the coordinate transformation appears in the `transformations` list of a `sequence` or is the
-`transformation` of an `inverseOf` transformation. In these two cases input and output SHOULD be omitted (see below for
-details).
+Exceptions are if the the coordinate transformation appears in the `transformations` list of a `sequence`
+or is the `transformation` of an `inverseOf` transformation.
+In these two cases input and output SHOULD be omitted (see below for details).
 
-Transformations in the `transformations` list of a `byDimensions` transformation MUST provide `input` and `output` as arrays
-of strings corresponding to axis names of the parent transformation's input and output coordinate systems (see below for
-details).
+Transformations in the `transformations` list of a `byDimensions` transformation MUST provide `input` and `output`
+as arrays of strings corresponding to axis names of the parent transformation's input and output coordinate systems
+(see below for details).
 
 <div class=example>
 
@@ -646,10 +661,11 @@ The sequence transformation's input corresponds to an array coordinate system at
 
 </div>
 
-Coordinate transformations are functions of *points* in the input space to *points* in the output space. We call this the "forward" direction.
+Coordinate transformations are functions of *points* in the input space to *points* in the output space.
+We call this the "forward" direction.
 Points are ordered lists of coordinates, where a coordinate is the location/value of that point along its corresponding axis.
-The indexes of axis dimensions correspond to indexes into transformation parameter arrays. For example, the scale transformation above
-defines the function:
+The indexes of axis dimensions correspond to indexes into transformation parameter arrays.
+For example, the scale transformation above defines the function:
 
 ```
 x = 0.5 * i
@@ -658,10 +674,10 @@ y = 1.2 * j
 
 i.e., the mapping from the first input axis to the first output axis is determined by the first scale parameter.
 
-When rendering transformed images and interpolating, implementations may need the "inverse" transformation - from the output to
-the input coordinate system. Inverse transformations will not be explicitly specified when they can be computed in closed form
-from the forward transformation. Inverse transformations used for image rendering may be specified using the `inverseOf`
-transformation type, for example:
+When rendering transformed images and interpolating, implementations may need the "inverse" transformation - 
+from the output to the input coordinate system.
+Inverse transformations will not be explicitly specified when they can be computed in closed form from the forward transformation.
+Inverse transformations used for image rendering may be specified using the `inverseOf` transformation type, for example:
 
 ```json
 {
@@ -673,20 +689,21 @@ transformation type, for example:
 }
 ```
 
-Implementations SHOULD be able to compute and apply the inverse of some coordinate transformations when they
-are computable in closed-form (as the [Transformation types](#transformation-types) section below indicates). If an
-operation is requested that requires the inverse of a transformation that can not be inverted in closed-form,
+Implementations SHOULD be able to compute and apply the inverse of some coordinate transformations 
+when they are computable in closed-form (as the [Transformation types](#transformation-types) section below indicates).
+If an operation is requested that requires the inverse of a transformation that can not be inverted in closed-form,
 implementations MAY estimate an inverse, or MAY output a warning that the requested operation is unsupported.
 
 
 #### Matrix transformations
 
-Two transformation types ([affine](#affine) and [rotation](#rotation)) are parametrized by matrices. Matrices are applied to
-column vectors that represent points in the input coordinate system. The first (last) axis in a coordinate system is the top
-(bottom) entry in the column vector. Matrices are stored as two-dimensional arrays, either as json or in a zarr array. When
-stored as a 2D zarr array, the first dimension indexes rows and the second dimension indexes columns (e.g., an array of
-`"shape":[3,4]` has 3 rows and 4 columns). When stored as a 2D json array, the inner array contains rows (e.g. `[[1,2,3],
-[4,5,6]]` has 2 rows and 3 columns).
+Two transformation types ([affine](#affine) and [rotation](#rotation)) are parametrized by matrices.
+Matrices are applied to column vectors that represent points in the input coordinate system.
+The first (last) axis in a coordinate system is the top (bottom) entry in the column vector.
+Matrices are stored as two-dimensional arrays, either as json or in a zarr array.
+When stored as a 2D zarr array, the first dimension indexes rows and the second dimension indexes columns
+(e.g., an array of `"shape":[3,4]` has 3 rows and 4 columns).
+When stored as a 2D json array, the inner array contains rows (e.g. `[[1,2,3], [4,5,6]]` has 2 rows and 3 columns).
 
 <div class=example>
 
@@ -718,18 +735,19 @@ results in the point [2,-1,3] because it is computed with the matrix-vector mult
 
 ### Transformation types
 
-Input and output dimensionality may be determined by the value of the "input" and "output" fields, respectively. If the value
-of "input" is an array, it's length gives the input dimension, otherwise the length of "axes" for the coordinate
-system with the name of the "input" value gives the input dimension.  If the value of "input" is an array, it's
-length gives the input dimension, otherwise it is given by the length of "axes" for the coordinate system with
-the name of the "input".  If the value of "output" is an array, its length gives the output dimension,
+Input and output dimensionality may be determined by the value of the "input" and "output" fields, respectively.
+If the value of "input" is an array, its length gives the input dimension, 
+otherwise the length of "axes" for the coordinate system with the name of the "input" value gives the input dimension.
+If the value of "input" is an array, its length gives the input dimension, 
+otherwise it is given by the length of "axes" for the coordinate system with the name of the "input".
+If the value of "output" is an array, its length gives the output dimension, 
 otherwise it is given by the length of "axes" for the coordinate system with the name of the "output".
 
 #### <a name="identity">identity</a>
 
-`identity` transformations map input coordinates to output coordinates without modification. The position of
-the ith axis of the output coordinate system is set to the position of the ith axis of the input coordinate
-system. `identity` transformations are invertible.
+`identity` transformations map input coordinates to output coordinates without modification.
+The position of the ith axis of the output coordinate system is set to the position of the ith axis of the input coordinate system.
+`identity` transformations are invertible.
 
 <div class=example>
 
@@ -750,11 +768,12 @@ y = j
 
 #### <a name="mapAxis">mapAxis</a>
 
-`mapAxis` transformations describe axis permutations as a mapping of axis names. Transformations MUST include a `mapAxis` field
-whose value is an object, all of whose values are strings. If the object contains `"x":"i"`, then the transform sets the value 
-of the output coordinate for axis "x" to the value of the coordinate of input axis "i" (think `x = i`). For every axis in its output coordinate
-system, the `mapAxis` MUST have a corresponding field. For every value of the object there MUST be an axis of the input
-coordinate system with that name. Note that the order of the keys could be reversed.
+`mapAxis` transformations describe axis permutations as a mapping of axis names.
+Transformations MUST include a `mapAxis` field whose value is an object, all of whose values are strings.
+If the object contains `"x":"i"`, then the transform sets the value of the output coordinate for axis "x" to the value of the coordinate of input axis "i" (think `x = i`).
+For every axis in its output coordinate system, the `mapAxis` MUST have a corresponding field.
+For every value of the object there MUST be an axis of the input coordinate system with that name.
+Note that the order of the keys could be reversed.
 
 
 <div class=example>
@@ -804,10 +823,10 @@ z = b
 
 #### <a name="translation">translation</a>
 
-`translation` transformations are special cases of affine transformations. When possible, a 
-translation transformation should be preferred to its equivalent affine. Input and output dimensionality MUST be
-identical and MUST equal the the length of the "translation" array (N). `translation` transformations are
-invertible.
+`translation` transformations are special cases of affine transformations.
+When possible, a translation transformation should be preferred to its equivalent affine.
+Input and output dimensionality MUST be identical and MUST equal the the length of the "translation" array (N).
+`translation` transformations are invertible.
 
 <dl>
   <dt><strong>path</strong></dt>
@@ -834,10 +853,10 @@ y = j - 1.42
 
 #### scale
 
-`scale` transformations are special cases of affine transformations. When possible, a scale transformation
-SHOULD be preferred to its equivalent affine. Input and output dimensionality MUST be identical and MUST equal
-the the length of the "scale" array (N). Values in the `scale` array SHOULD be non-zero; in that case, `scale`
-transformations are invertible.
+`scale` transformations are special cases of affine transformations.
+When possible, a scale transformation SHOULD be preferred to its equivalent affine.
+Input and output dimensionality MUST be identical and MUST equal the the length of the "scale" array (N).
+Values in the `scale` array SHOULD be non-zero; in that case, `scale` transformations are invertible.
 
 <dl>
   <dt><strong>path</strong></dt>
@@ -864,18 +883,24 @@ y = 2 * j
 
 #### <a name="affine">affine</a>
 
-`affine`s are [matrix transformations](#matrix-transformations) from N-dimensional inputs to M-dimensional outputs are
-represented as the upper `(M)x(N+1)` sub-matrix of a `(M+1)x(N+1)` matrix in [homogeneous
-coordinates](https://en.wikipedia.org/wiki/Homogeneous_coordinates) (see examples). This transformation type may be (but is not
-necessarily) invertible when `N` equals `M`. The matrix MUST be stored as a 2D array either as json or as a zarr array.
+`affine`s are [matrix transformations](#matrix-transformations) from N-dimensional inputs to M-dimensional outputs
+are represented as the upper `(M)x(N+1)` sub-matrix of a `(M+1)x(N+1)` matrix
+in [homogeneous coordinates](https://en.wikipedia.org/wiki/Homogeneous_coordinates) (see examples).
+This transformation type may be (but is not necessarily) invertible when `N` equals `M`.
+The matrix MUST be stored as a 2D array either as json or as a zarr array.
 
 <dl>
   <dt><strong>path</strong></dt>
-  <dd>  The path to a zarr-array containing the affine parameters.
-	The array at this path MUST be 2D whose shape MUST be `M x (N+1)`.</dd>
+  <dd>
+    The path to a zarr-array containing the affine parameters.
+    The array at this path MUST be 2D whose shape MUST be `M x (N+1)`.
+  </dd>
   <dt><strong>affine</strong></dt>
-  <dd> 	The affine parameters stored in JSON. The matrix MUST be stored as 2D nested array where the outer array MUST be length
-  `M` and the inner arrays MUST be length `N+1`.</dd> </dl>
+  <dd>
+    The affine parameters stored in JSON.
+    The matrix MUST be stored as 2D nested array where the outer array MUST be length `M` and the inner arrays MUST be length `N+1`.
+  </dd> 
+</dl>
 
 <div class=example>
     A 2D-2D example:
@@ -939,18 +964,26 @@ necessarily) invertible when `N` equals `M`. The matrix MUST be stored as a 2D a
 
 #### <a name="rotation">rotation</a>
 
-`rotation`s are [matrix transformations](#matrix-transformations) that are special cases of affine transformations. When possible, a rotation
-transformation SHOULD be preferred to its equivalent affine. Input and output dimensionality (N) MUST be identical. Rotations
-are stored as `NxN` matrices, see below, and MUST have determinant equal to one, with orthonormal rows and columns. The matrix
-MUST be stored as a 2D array either as json or in a zarr array. `rotation` transformations are invertible.
+`rotation`s are [matrix transformations](#matrix-transformations) that are special cases of affine transformations.
+When possible, a rotation transformation SHOULD be preferred to its equivalent affine.
+Input and output dimensionality (N) MUST be identical.
+Rotations are stored as `NxN` matrices, see below, and MUST have determinant equal to one, with orthonormal rows and columns.
+The matrix MUST be stored as a 2D array either as json or in a zarr array.
+`rotation` transformations are invertible.
 
 <dl>
   <dt><strong>path</strong></dt>
-  <dd>  The path to an array containing the affine parameters.
-	The array at this path MUST be 2D whose shape MUST be `N x N`.</dd>
+  <dd>
+    The path to an array containing the affine parameters.
+    The array at this path MUST be 2D whose shape MUST be `N x N`.
+  </dd>
   <dt><strong>rotation</strong></dt>
-  <dd> 	The  parameters stored in JSON. The matrix MUST be stored as a 2D nested array where the outer array MUST be length `N`
-  and the inner arrays MUST be length `N`.</dd> </dl>
+  <dd>
+    The  parameters stored in JSON. 
+    The matrix MUST be stored as a 2D nested array where the outer array MUST be length `N`
+    and the inner arrays MUST be length `N`.
+  </dd>
+</dl>
 
 <div class=example>
     A 2D example
@@ -971,16 +1004,15 @@ MUST be stored as a 2D array either as json or in a zarr array. `rotation` trans
 
 #### <a name="inverseOf">inverseOf</a>
 
-An `inverseOf` transformation contains another transformation (often non-linear), and indicates that
-transforming points from output to input coordinate systems is possible using the contained transformation.
-Transforming points from the input to the output coordinate systems requires the inverse of the contained
-transformation (if it exists).
+An `inverseOf` transformation contains another transformation (often non-linear),
+and indicates that transforming points from output to input coordinate systems is possible using the contained transformation.
+Transforming points from the input to the output coordinate systems requires the inverse of the contained transformation (if it exists).
 
 <div class=note>
-    Software libraries that perform image registration often return the transformation from fixed image
-    coordinates to moving image coordinates, because this "inverse" transformation is most often required
-    when rendering the transformed moving image. Results such as this may be enclosed in an `inverseOf`
-    transformation. This enables the "outer" coordinate transformation to specify the moving image coordinates
+    Software libraries that perform image registration often return the transformation from fixed image coordinates to moving image coordinates, 
+    because this "inverse" transformation is most often required when rendering the transformed moving image.
+    Results such as this may be enclosed in an `inverseOf` transformation.
+    This enables the "outer" coordinate transformation to specify the moving image coordinates
     as `input` and fixed image coordinates as `output`, a choice that many users and developers find intuitive.
 </div>
 
@@ -996,16 +1028,19 @@ transformation (if it exists).
 
 #### <a name="sequence">sequence</a>
 
-A `sequence` transformation consists of an ordered array of coordinate transformations, and is invertible if every coordinate
-transform in the array is invertible (though could be invertible in other cases as well). To apply a sequence transformation
-to a point in the input coordinate system, apply the first transformation in the list of transformations. Next, apply the second
-transformation to the result. Repeat until every transformation has been applied. The output of the last transformation is the
-result of the sequence.
+A `sequence` transformation consists of an ordered array of coordinate transformations,
+and is invertible if every coordinate transform in the array is invertible (though could be invertible in other cases as well).
+To apply a sequence transformation to a point in the input coordinate system,
+apply the first transformation in the list of transformations.
+Next, apply the second transformation to the result.
+Repeat until every transformation has been applied. 
+The output of the last transformation is the result of the sequence.
 
 <div class=note>
 
-Considering transformations as functions of points, if the list contains transformations `[f0, f1, f2]` in that order, applying
-this sequence to point `x` is equivalent to:
+Considering transformations as functions of points,
+if the list contains transformations `[f0, f1, f2]` in that order,
+applying this sequence to point `x` is equivalent to:
 
 ```
 f2(f1(f0(x)))
@@ -1015,19 +1050,19 @@ f2(f1(f0(x)))
 
 </div>
 
-The transformations included in the `transformations` array may omit their `input` and `output` fields under the conditions
-outlined below:
+The transformations included in the `transformations` array may omit their `input` and `output` fields
+under the conditions outlined below:
 
 - The `input` and `output` fields MAY be omitted for the following transformation types: 
     - `identity`, `scale`, `translation`, `rotation`, `affine`, `displacements`, `coordinates`
-- The `input` and `output` fields MAY be omitted for `inverseOf` transformations if those fields may be omitted for the
-    transformation it wraps
-- The `input` and `output` fields MAY be omitted for `bijection` transformations if the fields may be omitted for 
-    both its `forward` and `inverse` transformations
-- The `input` and `output` fields MAY be omitted for `sequence` transformations if the fields may be omitted for
-    all transformations in the sequence after flattening the nested sequence lists.
-- The `input` and `output` fields MUST be included for transformations of type: `mapAxis`, and `byDimension`, and 
-    under all other conditions.
+- The `input` and `output` fields MAY be omitted for `inverseOf` transformations 
+    if those fields may be omitted for the transformation it wraps
+- The `input` and `output` fields MAY be omitted for `bijection` transformations 
+    if the fields may be omitted for both its `forward` and `inverse` transformations
+- The `input` and `output` fields MAY be omitted for `sequence` transformations
+    if the fields may be omitted for all transformations in the sequence after flattening the nested sequence lists.
+- The `input` and `output` fields MUST be included for transformations of type: 
+    `mapAxis`, and `byDimension`, and under all other conditions.
 
 
 <dl>
@@ -1057,15 +1092,17 @@ and is invertible.
 
 #### <a name=coordinates-displacements>coordinates and displacements</a>
 
-`coordinates` and `displacements` transformations store coordinates or displacements in an array and interpret them as a vector
-field that defines a transformation. The arrays must have a dimension corresponding to every axis of the input coordinate
-system and one additional dimension to hold components of the vector. Applying the transformation amounts to looking up the
-appropriate vector in the array, interpolating if necessary, and treating it either as a position directly (`coordinates`) or a
-displacement of the input point (`displacements`).
+`coordinates` and `displacements` transformations store coordinates or displacements in an array
+and interpret them as a vector field that defines a transformation.
+The arrays must have a dimension corresponding to every axis of the input coordinate system
+and one additional dimension to hold components of the vector.
+Applying the transformation amounts to looking up the appropriate vector in the array, 
+interpolating if necessary, 
+and treating it either as a position directly (`coordinates`) or a displacement of the input point (`displacements`).
 
-These transformation types refer to an array at location specified by the `"path"` parameter.  The input and output coordinate
-systems for these transformations ("input / output coordinate systems") constrain the array size and the coordinate system
-metadata for the array ("field coordinate system").
+These transformation types refer to an array at location specified by the `"path"` parameter.
+The input and output coordinate systems for these transformations ("input / output coordinate systems")
+constrain the array size and the coordinate system metadata for the array ("field coordinate system").
 
 * If the input coordinate system has `N` axes, the array at location path MUST have `N+1` dimensions
 * The field coordinate system MUST contain an axis identical to every axis of its input coordinate system in the same order.
@@ -1078,9 +1115,9 @@ of the `i`th output axis. See the example below.
 
 <div class=example>
 
-In this example, the array located at `"displacementField"` MUST have three dimensions. One dimension MUST
-correspond to an axis with `type : displacement` (in this example, the last dimension), the other two dimensions MUST be axes
-that are identical to the axes of the `"in"` coordinate system.
+In this example, the array located at `"displacementField"` MUST have three dimensions.
+One dimension MUST correspond to an axis with `type : displacement` (in this example, the last dimension),
+the other two dimensions MUST be axes that are identical to the axes of the `"in"` coordinate system.
 
 ```json
 "coordinateSystems" : [
@@ -1120,8 +1157,9 @@ I.e. the y-displacement is first, because the y-axis is the first element of the
 </div>
 
 
-`coordinates` and `displacements` transformations are not invertible in general, but implementations MAY approximate their
-inverses. Metadata for these coordinate transforms have the following field: 
+`coordinates` and `displacements` transformations are not invertible in general,
+but implementations MAY approximate their inverses.
+Metadata for these coordinate transforms have the following field: 
 
 <dl>
   <dt><strong>path</strong></dt>
@@ -1236,12 +1274,11 @@ Example metadata for the array data at path `displacements` above:
 }
 ```
 If the array in `displacements` contains the data: `[-1, 0, 1]`, 
-this transformation maps the point `[1.0]` to the point `[0.5]`. A scale
-transformation maps the array coordinates to the "x" axis. Using the inverse
-of the scale transform, we see that we need the position `0.5` in array coordinates.
-The transformation specifies linear interpolation, which in this case yields
-`(0.5 * -1) + (0.5 * 0) = -0.5`. That value gives us the displacement of the
-input point, hence the output is `1.0 + (-0.5) = 0.5`.
+this transformation maps the point `[1.0]` to the point `[0.5]`.
+A scale transformation maps the array coordinates to the "x" axis.
+Using the inverse of the scale transform, we see that we need the position `0.5` in array coordinates.
+The transformation specifies linear interpolation, which in this case yields `(0.5 * -1) + (0.5 * 0) = -0.5`.
+That value gives us the displacement of the input point, hence the output is `1.0 + (-0.5) = 0.5`.
 
 
 #### <a name=byDimension>byDimension</a>
@@ -1251,11 +1288,12 @@ on subsets of dimensions.
 
 <dl>
   <dt><strong>transformations</strong></dt>
-  <dd>  A list of transformations, each of which applies to a (non-strict) subset of input and output dimensions (axes). 
-        The values of `input` and `output` fields MUST be an array of strings.
-        Every axis name in `input` MUST correspond to a name of some axis in this parent object's `input` coordinate system.
-        Every axis name in the parent byDimension's `output` MUST appear in exactly one of its child transformations' `output`.
-        </dd>
+  <dd> 
+    A list of transformations, each of which applies to a (non-strict) subset of input and output dimensions (axes). 
+    The values of `input` and `output` fields MUST be an array of strings.
+    Every axis name in `input` MUST correspond to a name of some axis in this parent object's `input` coordinate system.
+    Every axis name in the parent byDimension's `output` MUST appear in exactly one of its child transformations' `output`.
+  </dd>
 </dl>
 
 
@@ -1290,7 +1328,9 @@ path: examples/transformations/byDimensionInvalid1.json
 highlight: json
 </pre>
 
-It is invalid for two reasons. First because input `0` used by the scale transformation is not an axis of the `byDimension` transformation's `input`. Second, the `x` axis of the `output` does not appear in the `output` of any child transformation.
+It is invalid for two reasons.
+First, because input `0` used by the scale transformation is not an axis of the `byDimension` transformation's `input`.
+Second, the `x` axis of the `output` does not appear in the `output` of any child transformation.
 
 </div>
 
@@ -1310,18 +1350,19 @@ This transformation is invalid because the output axis `x` appears in more than 
 
 #### <a name="bijection">bijection</a>
 
-A bijection transformation is an invertible transformation in which both the `forward` and `inverse` transformations
-are explicitly defined. Each direction SHOULD be a transformation type that is not closed-form invertible.
-Its' input and output spaces MUST have equal dimension. The input and output dimensions for the both the forward
-and inverse transformations MUST match bijection's input and output space dimensions.
+A bijection transformation is an invertible transformation in which both the `forward` and `inverse` transformations are explicitly defined.
+Each direction SHOULD be a transformation type that is not closed-form invertible.
+Its' input and output spaces MUST have equal dimension.
+The input and output dimensions for the both the forward and inverse transformations MUST match bijection's input and output space dimensions.
 
-`input` and `output` fields MAY be omitted for the `forward` and `inverse` transformations, in which case
-the `forward` transformation's `input` and `output` are understood to match the bijection's, and the `inverse`
-transformation's `input` (`output`) matches the bijection's `output` (`input`), see the example below.
+`input` and `output` fields MAY be omitted for the `forward` and `inverse` transformations,
+in which case the `forward` transformation's `input` and `output` are understood to match the bijection's,
+and the `inverse` transformation's `input` (`output`) matches the bijection's `output` (`input`):
+see the example below.
 
-Practically, non-invertible transformations have finite extents, so bijection transforms should only be expected
-to be correct / consistent for points that fall within those extents. It may not be correct for any point of
-appropriate dimensionality.
+Practically, non-invertible transformations have finite extents,
+so bijection transforms should only be expected to be correct / consistent for points that fall within those extents.
+It may not be correct for any point of appropriate dimensionality.
 
 <div class=example>
 
@@ -1352,19 +1393,24 @@ It is stored in a multiple resolution representation.
 Each "multiscales" dictionary MUST contain the field "coordinateSystems", see [[#coord-sys-md]], with the following constraints.
 The length of "axes" must be between 2 and 5 and MUST be equal to the dimensionality of the zarr arrays storing the image data (see "datasets:path").
 The "axes" MUST contain 2 or 3 entries of "type:space" and MAY contain one additional entry of "type:time" and MAY contain one additional entry of "type:channel" or a null / custom type.
-The order of the entries MUST correspond to the order of dimensions of the zarr arrays. In addition, the entries MUST be ordered by "type" where the "time" axis must come first (if present), followed by the  "channel" or custom axis (if present) and the axes of type "space".
+The order of the entries MUST correspond to the order of dimensions of the zarr arrays.
+In addition, the entries MUST be ordered by "type" where the "time" axis must come first (if present),
+followed by the  "channel" or custom axis (if present) and the axes of type "space".
 If there are three spatial axes where two correspond to the image plane ("yx") and images are stacked along the other (anisotropic) axis ("z"), the spatial axes SHOULD be ordered as "zyx".
 
 Each "multiscales" dictionary MUST contain the field "datasets", which is a list of dictionaries describing the arrays storing the individual resolution levels.
-Each dictionary in "datasets" MUST contain the field "path", whose value contains the path to the array for this resolution relative
-to the current zarr group. The "path"s MUST be ordered from largest (i.e. highest resolution) to smallest.
+Each dictionary in "datasets" MUST contain the field "path", whose value contains the path to the array for this resolution relative to the current zarr group.
+The "path"s MUST be ordered from largest (i.e. highest resolution) to smallest.
 
-Each "datasets" dictionary MUST have the same number of dimensions and MUST NOT have more than 5 dimensions. The number of dimensions and order MUST correspond to number and order of "axes".
+Each "datasets" dictionary MUST have the same number of dimensions and MUST NOT have more than 5 dimensions.
+The number of dimensions and order MUST correspond to number and order of "axes".
 Each dictionary in "datasets" MUST contain the field "coordinateTransformations", which contains a list of transformations that map the data coordinates to the physical coordinates (as specified by "axes") for this resolution level.
 The transformations are defined according to [[#trafo-md]]. 
 
-They MUST contain exactly one `scale` transformation that specifies the pixel size in physical units or time duration. If scaling information is not available or applicable for one of the axes, the value MUST express the scaling factor between the current resolution and the first resolution for the given axis, defaulting to 1.0 if there is no downsampling along the axis.
-It MAY contain exactly one `translation` that specifies the offset from the origin in physical units. If `translation` is given it MUST be listed after `scale` to ensure that it is given in physical coordinates.
+They MUST contain exactly one `scale` transformation that specifies the pixel size in physical units or time duration.
+If scaling information is not available or applicable for one of the axes, the value MUST express the scaling factor between the current resolution and the first resolution for the given axis, defaulting to 1.0 if there is no downsampling along the axis.
+It MAY contain exactly one `translation` that specifies the offset from the origin in physical units.
+If `translation` is given it MUST be listed after `scale` to ensure that it is given in physical coordinates.
 The requirements (only `scale` and `translation`, restrictions on order) are in place to provide a simple mapping from data coordinates to physical coordinates while being compatible with the general transformation spec.
 
 Each "multiscales" dictionary MAY contain the field "coordinateTransformations", describing transformations that are applied to all resolution levels in the same manner.
@@ -1399,8 +1445,7 @@ if not datasets:
 "omero" metadata (transitional) {#omero-md}
 -------------------------------------------
 
-[=Transitional=] information specific to the channels of an image and how to render it
-can be found under the "omero" key in the group-level metadata:
+[=Transitional=] information specific to the channels of an image and how to render it can be found under the "omero" key in the group-level metadata:
 
 ```json
 "id": 1,                              # ID in OMERO
@@ -1440,19 +1485,22 @@ It MUST also contain the fields "start" and "end", which are the start and end v
 "labels" metadata {#labels-md}
 ------------------------------
 
-In OME-Zarr, Zarr arrays representing pixel-annotation data are stored in a group called "labels". Some applications--notably image segmentation--produce 
-a new image that is in the same coordinate system as a corresponding multiscale image (usually having the same dimensions and coordinate transformations). 
-This new image is composed of integer values corresponding to certain labels with custom meanings. For example, pixels take the value 1 or 0 
-if the corresponding pixel in the original image represents cellular space or intercellular space, respectively. 
+In OME-Zarr, Zarr arrays representing pixel-annotation data are stored in a group called "labels".
+Some applications--notably image segmentation--produce a new image that is in the same coordinate system as a corresponding multiscale image (usually having the same dimensions and coordinate transformations). 
+This new image is composed of integer values corresponding to certain labels with custom meanings.
+For example, pixels take the value 1 or 0 if the corresponding pixel in the original image represents cellular space or intercellular space, respectively. 
 Such an image is referred to in this specification as a 'label image'. 
 
 The "labels" group is nested within an image group, at the same level of the Zarr hierarchy as the resolution levels for the original image. 
-The "labels" group is not itself an image; it contains images. The pixels of the label images MUST be integer data types, i.e. one of 
-[`uint8`, `int8`, `uint16`, `int16`, `uint32`, `int32`, `uint64`, `int64`]. Intermediate groups between "labels" and the images within it are allowed, 
-but these MUST NOT contain metadata. Names of the images in the "labels" group are arbitrary.
+The "labels" group is not itself an image; it contains images.
+The pixels of the label images MUST be integer data types, 
+i.e. one of [`uint8`, `int8`, `uint16`, `int16`, `uint32`, `int32`, `uint64`, `int64`]. 
+Intermediate groups between "labels" and the images within it are allowed, but these MUST NOT contain metadata. 
+Names of the images in the "labels" group are arbitrary.
 
-The OME-Zarr Metadata in the `zarr.json` file associated with the "labels" group MUST contain a JSON object with the key `labels`, whose value is a JSON array of paths to the 
-labeled multiscale image(s). All label images SHOULD be listed within this metadata file. For example:
+The OME-Zarr Metadata in the `zarr.json` file associated with the "labels" group MUST contain a JSON object with the key `labels`,
+whose value is a JSON array of paths to the labeled multiscale image(s).
+All label images SHOULD be listed within this metadata file. For example:
 
 ```json
 {
@@ -1468,21 +1516,23 @@ labeled multiscale image(s). All label images SHOULD be listed within this metad
 }
 ```
 
-The `zarr.json` file for the label image MUST implement the multiscales specification. Within the `multiscales` object, the JSON array 
-associated with the `datasets` key MUST have the same number of entries (scale levels) as the original unlabeled image. 
+The `zarr.json` file for the label image MUST implement the multiscales specification. 
+Within the `multiscales` object, the JSON array associated with the `datasets` key MUST have the same number of entries (scale levels) as the original unlabeled image. 
 
 In addition to the `multiscales` key, the OME-Zarr Metadata in this image-level `zarr.json` file SHOULD contain another key, `image-label`, 
-whose value is also a JSON object. The `image-label` object stores information about the display colors, source image, and optionally, 
-further arbitrary properties of the label image. That `image-label` object SHOULD contain the following keys: first, a `colors` key, 
-whose value MUST be a JSON array describing color information for the unique label values. Second, a `version` key, whose value MUST be a 
-string specifying the version of the OME-Zarr `image-label` schema.
+whose value is also a JSON object.
+The `image-label` object stores information about the display colors, source image, and optionally, 
+further arbitrary properties of the label image.
+That `image-label` object SHOULD contain the following keys: first, a `colors` key, 
+whose value MUST be a JSON array describing color information for the unique label values.
+Second, a `version` key, whose value MUST be a string specifying the version of the OME-Zarr `image-label` schema.
 
-Conforming readers SHOULD display labels using the colors specified by the `colors` JSON array, as follows. This array contains one 
-JSON object for each unique custom label. Each of these objects MUST contain the `label-value` key, whose value MUST be the integer 
-corresponding to a particular label. In addition to the `label-value` key, the objects in this array MAY contain an `rgba` key whose 
-value MUST be an array of four integers between 0 and 255, inclusive. These integers represent the `uint8` values of red, green, and 
-blue that comprise the final color to be displayed at the pixels with this label. The fourth integer in the `rgba` array represents alpha, 
-or the opacity of the color. Additional keys under `colors` are allowed. 
+Conforming readers SHOULD display labels using the colors specified by the `colors` JSON array, as follows.
+This array contains one JSON object for each unique custom label.
+Each of these objects MUST contain the `label-value` key, whose value MUST be the integer corresponding to a particular label.
+In addition to the `label-value` key, the objects in this array MAY contain an `rgba` key whose value MUST be an array of four integers between 0 and 255, inclusive.
+These integers represent the `uint8` values of red, green, and blue that comprise the final color to be displayed at the pixels with this label.
+The fourth integer in the `rgba` array represents alpha, or the opacity of the color. Additional keys under `colors` are allowed. 
 
 Next, the `image-label` object MAY contain the following keys: a `properties` key, and a `source` key.
 
@@ -1508,69 +1558,55 @@ which correspond to cellular space, will be displayed as 50% green and 50% opaci
 "plate" metadata {#plate-md}
 ----------------------------
 
-For high-content screening datasets, the plate layout can be found under the
-custom attributes of the plate group under the `plate` key in the group-level metadata.
+For high-content screening datasets, the plate layout can be found under the custom attributes of the plate group under the `plate` key in the group-level metadata.
 
-The `plate` dictionary MAY contain an `acquisitions` key whose value MUST be a list of
-JSON objects defining the acquisitions for a given plate to which wells can refer to. Each
-acquisition object MUST contain an `id` key whose value MUST be an unique integer identifier
-greater than or equal to 0 within the context of the plate to which fields of view can refer
-to (see #well-md).
-Each acquisition object SHOULD contain a `name` key whose value MUST be a string identifying
-the name of the acquisition. Each acquisition object SHOULD contain a `maximumfieldcount`
-key whose value MUST be a positive integer indicating the maximum number of fields of view for the
-acquisition. Each acquisition object MAY contain a `description` key whose value MUST be a
-string specifying a description for the acquisition. Each acquisition object MAY contain
-a `starttime` and/or `endtime` key whose values MUST be integer epoch timestamps specifying
-the start and/or end timestamp of the acquisition.
+The `plate` dictionary MAY contain an `acquisitions` key whose value MUST be a list of JSON objects defining the acquisitions for a given plate to which wells can refer to.
+Each acquisition object MUST contain an `id` key whose value MUST be an unique integer identifier greater than or equal to 0
+within the context of the plate to which fields of view can refer to (see #well-md).
+Each acquisition object SHOULD contain a `name` key whose value MUST be a string identifying the name of the acquisition.
+Each acquisition object SHOULD contain a `maximumfieldcount` key whose value MUST be a positive integer indicating the maximum number of fields of view for the acquisition.
+Each acquisition object MAY contain a `description` key whose value MUST be a string specifying a description for the acquisition.
+Each acquisition object MAY contain a `starttime` and/or `endtime` key whose values MUST be integer epoch timestamps specifying the start and/or end timestamp of the acquisition.
 
-The `plate` dictionary MUST contain a `columns` key whose value MUST be a list of JSON objects
-defining the columns of the plate. Each column object defines the properties of
-the column at the index of the object in the list. Each column in the physical plate
-MUST be defined, even if no wells in the column are defined. Each column object MUST
-contain a `name` key whose value is a string specifying the column name. The `name` MUST
-contain only alphanumeric characters, MUST be case-sensitive, and MUST NOT be a duplicate of any
-other `name` in the `columns` list. Care SHOULD be taken to avoid collisions on
-case-insensitive filesystems (e.g. avoid using both `Aa` and `aA`).
+The `plate` dictionary MUST contain a `columns` key whose value MUST be a list of JSON objects defining the columns of the plate.
+Each column object defines the properties of the column at the index of the object in the list.
+Each column in the physical plate MUST be defined, even if no wells in the column are defined.
+Each column object MUST contain a `name` key whose value is a string specifying the column name.
+The `name` MUST contain only alphanumeric characters, MUST be case-sensitive, and MUST NOT be a duplicate of any other `name` in the `columns` list.
+Care SHOULD be taken to avoid collisions on case-insensitive filesystems (e.g. avoid using both `Aa` and `aA`).
 
-The `plate` dictionary SHOULD contain a `field_count` key whose value MUST be a positive integer
-defining the maximum number of fields per view across all wells.
+The `plate` dictionary SHOULD contain a `field_count` key whose value MUST be a positive integer defining the maximum number of fields per view across all wells.
 
-The `plate` dictionary SHOULD contain a `name` key whose value MUST be a string defining the
-name of the plate.
+The `plate` dictionary SHOULD contain a `name` key whose value MUST be a string defining the name of the plate.
 
-The `plate` dictionary MUST contain a `rows` key whose value MUST be a list of JSON objects
-defining the rows of the plate. Each row object defines the properties of
-the row at the index of the object in the list. Each row in the physical plate
-MUST be defined, even if no wells in the row are defined. Each defined row MUST
-contain a `name` key whose value MUST be a string defining the row name. The `name` MUST
-contain only alphanumeric characters, MUST be case-sensitive, and MUST NOT be a duplicate of any
-other `name` in the `rows` list. Care SHOULD be taken to avoid collisions on
-case-insensitive filesystems (e.g. avoid using both `Aa` and `aA`).
+The `plate` dictionary MUST contain a `rows` key whose value MUST be a list of JSON objects defining the rows of the plate.
+Each row object defines the properties of the row at the index of the object in the list.
+Each row in the physical plate MUST be defined, even if no wells in the row are defined.
+Each defined row MUST contain a `name` key whose value MUST be a string defining the row name.
+The `name` MUST contain only alphanumeric characters, MUST be case-sensitive, and MUST NOT be a duplicate of any other `name` in the `rows` list.
+Care SHOULD be taken to avoid collisions on case-insensitive filesystems (e.g. avoid using both `Aa` and `aA`).
 
-The `plate` dictionary MUST contain a `version` key whose value MUST be a string specifying the
-version of the plate specification.
+The `plate` dictionary MUST contain a `version` key whose value MUST be a string specifying the version of the plate specification.
 
-The `plate` dictionary MUST contain a `wells` key whose value MUST be a list of JSON objects
-defining the wells of the plate. Each well object MUST contain a `path` key whose value MUST
-be a string specifying the path to the well subgroup. The `path` MUST consist of a `name` in
-the `rows` list, a file separator (`/`), and a `name` from the `columns` list, in that order.
+The `plate` dictionary MUST contain a `wells` key whose value MUST be a list of JSON objects defining the wells of the plate.
+Each well object MUST contain a `path` key whose value MUST be a string specifying the path to the well subgroup.
+The `path` MUST consist of a `name` in the `rows` list, a file separator (`/`), and a `name` from the `columns` list, in that order.
 The `path` MUST NOT contain additional leading or trailing directories.
-Each well object MUST contain both a `rowIndex` key whose value MUST be an integer identifying
-the index into the `rows` list and a `columnIndex` key whose value MUST be an integer identifying
-the index into the `columns` list. `rowIndex` and `columnIndex` MUST be 0-based. The
-`rowIndex`, `columnIndex`, and `path` MUST all refer to the same row/column pair.
+Each well object MUST contain both a `rowIndex` key whose value MUST be an integer identifying the index into the `rows` list and a `columnIndex` key
+whose value MUST be an integer identifying the index into the `columns` list.
+`rowIndex` and `columnIndex` MUST be 0-based.
+The `rowIndex`, `columnIndex`, and `path` MUST all refer to the same row/column pair.
 
-For example the following JSON object defines a plate with two acquisitions and
-6 wells (2 rows and 3 columns), containing up to 2 fields of view per acquisition.
+For example the following JSON object defines a plate with two acquisitions and 6 wells (2 rows and 3 columns),
+containing up to 2 fields of view per acquisition.
 
 <pre class=include-code>
 path: examples/plate_strict/plate_6wells.json
 highlight: json
 </pre>
 
-The following JSON object defines a sparse plate with one acquisition and
-2 wells in a 96 well plate, containing one field of view per acquisition.
+The following JSON object defines a sparse plate with one acquisition and 2 wells in a 96 well plate,
+containing one field of view per acquisition.
 
 <pre class=include-code>
 path: examples/plate_strict/plate_2wells.json
@@ -1580,33 +1616,27 @@ highlight: json
 "well" metadata {#well-md}
 --------------------------
 
-For high-content screening datasets, the metadata about all fields of views
-under a given well can be found under the "well" key in the attributes of the
-well group.
+For high-content screening datasets, the metadata about all fields of views under a given well
+can be found under the "well" key in the attributes of the well group.
 
-The `well` dictionary MUST contain an `images` key whose value MUST be a list of JSON objects
-specifying all fields of views for a given well. Each image object MUST contain a
-`path` key whose value MUST be a string specifying the path to the field of view. The `path`
-MUST contain only alphanumeric characters, MUST be case-sensitive, and MUST NOT be a duplicate
-of any other `path` in the `images` list. If multiple acquisitions were performed in the plate,
-it MUST contain an `acquisition` key whose value MUST be an integer identifying the acquisition
+The `well` dictionary MUST contain an `images` key whose value MUST be a list of JSON objects specifying all fields of views for a given well.
+Each image object MUST contain a `path` key whose value MUST be a string specifying the path to the field of view.
+The `path` MUST contain only alphanumeric characters, MUST be case-sensitive, and MUST NOT be a duplicate of any other `path` in the `images` list.
+If multiple acquisitions were performed in the plate, it MUST contain an `acquisition` key whose value MUST be an integer identifying the acquisition 
 which MUST match one of the acquisition JSON objects defined in the plate metadata (see #plate-md).
 
-The `well` dictionary SHOULD contain a `version` key whose value MUST be a string specifying the
-version of the well specification.
+The `well` dictionary SHOULD contain a `version` key whose value MUST be a string specifying the version of the well specification.
 
-For example the following JSON object defines a well with four fields of
-view. The first two fields of view were part of the first acquisition while
-the last two fields of view were part of the second acquisition.
+For example the following JSON object defines a well with four fields of view.
+The first two fields of view were part of the first acquisition while the last two fields of view were part of the second acquisition.
 
 <pre class=include-code>
 path: examples/well_strict/well_4fields.json
 highlight: json
 </pre>
 
-The following JSON object defines a well with two fields of view in a plate with
-four acquisitions. The first field is part of the first acquisition, and the second
-field is part of the last acquisition.
+The following JSON object defines a well with two fields of view in a plate with four acquisitions.
+The first field is part of the first acquisition, and the second field is part of the last acquisition.
 
 <pre class=include-code>
 path: examples/well_strict/well_2fields.json

--- a/transform-details.bs
+++ b/transform-details.bs
@@ -28,15 +28,15 @@ Status Text: (an "editor's draft") will not necessarily be supported.
 Coordinates and Axes {#coords-axes}
 =====================
 
-OME-NGFF datasets are arrays that hold values. The arrays may be indexed by discrete (integer)
-coordinates in order to obtain a corresponding value. If values are desired at continuous (real-valued)
-coordinates, then interpolation is required.
+OME-NGFF datasets are arrays that hold values.
+The arrays may be indexed by discrete (integer) coordinates in order to obtain a corresponding value.
+If values are desired at continuous (real-valued) coordinates, then interpolation is required.
 
 Interpolation {#interp}
 ---------------------
 
-Interpolation is the process of producing values at continuous coordinates from data sampled at discrete
-coordinates. "Nearest-neighbor" and "N-Linear" are the two most commonly used interpolation methods.
+Interpolation is the process of producing values at continuous coordinates from data sampled at discrete coordinates.
+"Nearest-neighbor" and "N-Linear" are the two most commonly used interpolation methods.
 
 
 Pixel coordinates {#pix-coords}
@@ -67,8 +67,9 @@ This document describes background and motivation that is outside the NGFF speci
 Direction {#direction}
 ---------------------
 
-Specified coordinate transforms are in the "forward" direction. They represent functions
-from *points* in the input space to *points* in the output space. For example, the transformation `"ij2xy"`
+Specified coordinate transforms are in the "forward" direction.
+They represent functions from *points* in the input space to *points* in the output space.
+For example, the transformation `"ij2xy"`
 
 
 ```json
@@ -96,9 +97,9 @@ Recommendations {#recommendations}
 "Native" physical space 
 ---------------------
 
-Datasets SHOULD define a transformation from array space to their "native physical space."
-This transformation SHOULD describe physical pixel spacing and origin only, and therefore SHOULD consist of
-`scale` and/or `translation` types only.
+Datasets SHOULD define a transformation from array space to their "native physical space.".
+This transformation SHOULD describe physical pixel spacing and origin only,
+and therefore SHOULD consist of `scale` and/or `translation` types only.
 
 Subsequent reorientation / registration transformations SHOULD use this native space as their `input_space`,
 i.e., transformations should be defined in physical coordinates.


### PR DESCRIPTION
Roughly guided by the spec here https://sembr.org/

This PR contains no changes to the text other than whitespace (and removing a couple of errant apostrophes).

This is obviously a very bikeshed-prone topic; all I'll say is that I think the benefits far outweigh the costs, and also that if such a change is to be made, it must be now, while no other PRs target this repo which would need rebasing.

## Pros

- Plays much more nicely with version control as single units of thought are added, removed, moved, or updated
- Editors don't waste time reflowing the whole paragraph when inserting text into the middle

## Cons

- Right hand edge is more ragged
- Some lines are longer than some editors' width
   - Users are welcome to configure their editors for soft-wrapping
   - It can be useful to be reminded not to write clauses which are too long