### PR TITLE
Use a keepachangelog CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,95 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Coordinate systems
+
+### Changed
+
+- `coordinateTransformations` metadata
+
+## [0.5.2] - 2025-01-10
+
+### Changed
+
+- Clarified that the `dimension_names` field in `axes` MUST be included
+
+## [0.5.1] - 2025-01-10
+
+### Fixed
+
+- Re-added the improved omero description from PR-191
+
+## [0.5.0] - 2024-11-21
+
+### Changed
+
+- Use Zarr v3 in OME-Zarr (see [RFC-2](https://ngff.openmicroscopy.org/rfc/2))
+
+## [0.4.2] - 2023-02-09
+
+### Changed
+
+- Expanded "labels" description
+
+## [0.4.1] - 2022-09-26
+
+### Added
+
+- Transitional metadata for image collections ("bioformats2raw.layout")
+
+## [0.4.0] - 2022-02-08
+
+### Added
+
+- multiscales: axes type, units and coordinateTransformations
+- plate: rowIndex/columnIndex
+
+## [0.3.0] - 2021-08-24
+
+### Added
+
+- Axes field to multiscale metadata
+
+## [0.2.0] - 2021-03-29
+
+### Changed
+
+- Chunk dimension separator to "/"
+
+## [0.1.4] - 2020-11-26
+
+### Added
+
+- HCS specification
+
+## [0.1.3] - 2020-09-14
+
+### Added
+
+- Labels specification
+
+## [0.1.2] - 2020-05-07
+
+### Added
+
+- Description of "omero" metadata
+
+## [0.1.1] - 2020-05-06
+
+### Added
+
+- Information on the ordering of resolutions
+
+## [0.1.0] - 2020-04-20
+
+### Added
+
+- First version for internal demo

--- a/index.bs
+++ b/index.bs
@@ -1637,86 +1637,9 @@ The latest edition is available at [https://ngff.openmicroscopy.org/latest/](htt
 Version History {#history}
 ==========================
 
-<table>
-  <thead>
-    <tr>
-      <td>Revision</td>
-      <td>Date</td>
-      <td>Description</td>
-    </tr>
-  </thead>
-  <tr>
-    <td>0.5.2</td>
-    <td>2025-01-10</td>
-    <td>Clarify that the <code>dimension_names</code> field in <code>axes</code> MUST be included.</td>
-  </tr>
-  <tr>
-    <td>0.5.1</td>
-    <td>2025-01-10</td>
-    <td>Re-add the improved omero description in PR-191.</td>
-  </tr>
-  <tr>
-    <td>0.5.0</td>
-    <td>2024-11-21</td>
-    <td>use Zarr v3 in OME-Zarr, see <a href="https://ngff.openmicroscopy.org/rfc/2">RFC-2</a>.</td>
-  </tr>
-  <tr>
-    <td>0.4.1</td>
-    <td>2023-02-09</td>
-    <td>expand on "labels" description</td>
-  </tr>
-  <tr>
-    <td>0.4.1</td>
-    <td>2022-09-26</td>
-    <td>transitional metadata for image collections ("bioformats2raw.layout")</td>
-  </tr>
-  <tr>
-    <td>0.4.0</td>
-    <td>2022-02-08</td>
-    <td>multiscales: add axes type, units and coordinateTransformations</td>
-  </tr>
-  <tr>
-    <td>0.4.0</td>
-    <td>2022-02-08</td>
-    <td>plate: add rowIndex/columnIndex                </td>
-  </tr>
-  <tr>
-    <td>0.3.0</td>
-    <td>2021-08-24</td>
-    <td>Add axes field to multiscale metadata     </td>
-  </tr>
-  <tr>
-    <td>0.2.0</td>
-    <td>2021-03-29</td>
-    <td>Change chunk dimension separator to "/"   </td>
-  </tr>
-  <tr>
-    <td>0.1.4</td>
-    <td>2020-11-26</td>
-    <td>Add HCS specification                      </td>
-  </tr>
-  <tr>
-    <td>0.1.3</td>
-    <td>2020-09-14</td>
-    <td>Add labels specification                   </td>
-  </tr>
-  <tr>
-    <td>0.1.2     </td>
-    <td>2020-05-07</td>
-    <td>Add description of "omero" metadata        </td>
-  </tr>
-  <tr>
-    <td>0.1.1     </td>
-    <td>2020-05-06</td>
-    <td>Add info on the ordering of resolutions    </td>
-  </tr>
-  <tr>
-    <td>0.1.0     </td>
-    <td>2020-04-20</td>
-    <td>First version for internal demo            </td>
-  </tr>
-</table>
-
+<pre class=include>
+path: CHANGELOG.md
+</pre>
 
 <pre class="biblio">
 {


### PR DESCRIPTION
The current HTML table means hand-writing HTML and discourages detailed descriptions of every change made in a release.
The markdown form is easier to write and maintain, keeps track of unreleased changes, and more easily supports multiple changes within a version.

I've gone with the format described here https://keepachangelog.com/en/1.0.0/ but I'm not married to the Added/Changed/Removed subsections; could use a free list for author ease.

This is currently a draft because it uses an `include` directive, which behaves differently if the spec is at the top level or not (path must be relative to the root spec).
This is a top-level spec in the context of this repo, but once it's submoduled into  ome/ngff it might not be.