### PR TITLE
remove U. Dundee from footer

### DIFF
--- a/ngff_spec/pre_build.py
+++ b/ngff_spec/pre_build.py
@@ -148,8 +148,7 @@ def build_footer():
     footer_content = f"""
 <div>
     Copyright © 2020-{year}
-    <a href="https://www.openmicroscopy.org/"><abbr title="Open Microscopy Environment">OME</abbr></a><sup>®</sup>
-    (<a href="https://dundee.ac.uk/"><abbr title="University of Dundee">U. Dundee</abbr></a>).
+    <a href="https://www.openmicroscopy.org/"><abbr title="Open Microscopy Environment">OME</abbr></a><sup>®</sup>.
     OME trademark rules apply.
 </div>
 """


### PR DESCRIPTION
Closes #22 

This pull request makes a minor update to the footer content in `ngff_spec/pre_build.py`. The change removes the reference to the University of Dundee from the copyright line.

- Footer now omits the mention of "University of Dundee" and its associated link, simplifying the copyright statement.