### PR TITLE
Add RFC5 to version history

### DIFF
--- a/ngff_spec/version_history.md
+++ b/ngff_spec/version_history.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.6dev1] - 2025-11-18
+
+### Added
+
+Initial proposal for RFC-5: Transforms. [See proposal text](https://ngff.openmicroscopy.org/rfc/5/versions/1/index.html).
+
 ## [0.5.2] - 2025-01-10
 
 ### Changed


### PR DESCRIPTION
Adds RFC5 (initial version) to changelog on built pages.