### PR TITLE
No local version in setuptools_scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ testing = [
 [tool.setuptools_scm]
 write_to = "ngff_spec/_version.py"
 fallback_version = "0.0.1+nogit"
+local_scheme = "no-local-version"
 
 [build-system]
 requires = ["setuptools >= 77.0.3", "setuptools-scm"]


### PR DESCRIPTION
Currently, the readthedocs build is failing because the build tool (`setuptools_scm`) doesn't know how to create a new local version from the git tag. Essentially, when it installs a version (i.e., `0.6.dev1`), it tries to create a *local* version of this like `0.6.dev1+098234`, which can be helpful to distinguish a local development version from a released version. I'm not sure this is strictly relevant here, so this PR will make stuptools just install stuff with the latest git tag.

Tested with a RTD build on this branch, works 👍 