### PR TITLE
Tidy up schema titles and descriptions

### DIFF
--- a/schemas/_version.schema
+++ b/schemas/_version.schema
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ngff.openmicroscopy.org/0.6.dev2/schemas/_version.schema",
-  "title": "OME-Zarr Metadata version",
-  "description": "The version of the OME-Zarr Metadata",
+  "title": "OME-Zarr version",
+  "description": "OME-Zarr version.",
   "type": "string",
   "enum": [
     "0.6.dev2"

--- a/schemas/axes.schema
+++ b/schemas/axes.schema
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ngff.openmicroscopy.org/0.6.dev2/schemas/axes.schema",
-  "title": "NGFF Axes",
-  "description": "JSON from OME-NGFF .zattrs",
+  "title": "Axes",
+  "description": "OME-Zarr Axes.",
   "type": "array",
   "uniqueItems": true,
   "minItems": 1,

--- a/schemas/bf2raw.schema
+++ b/schemas/bf2raw.schema
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ngff.openmicroscopy.org/0.6.dev2/schemas/bf2raw.schema",
-  "title": "OME-Zarr container produced by bioformats2raw",
-  "description": "The zarr.json attributes key",
+  "title": "bioformats2raw",
+  "description": "OME-Zarr bioformats2raw metadata.",
   "type": "object",
   "properties": {
     "ome": {

--- a/schemas/coordinate_systems.schema
+++ b/schemas/coordinate_systems.schema
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ngff.openmicroscopy.org/0.6.dev2/schemas/coordinate_systems.schema",
-  "title": "NGFF CoordinateSystem",
-  "description": "JSON from OME-NGFF .zattrs",
+  "title": "Coordinate systems",
+  "description": "OME-Zarr coordinate system.",
   "type": "array",
   "uniqueItems": true,
   "items": {

--- a/schemas/coordinate_systems_and_transforms.schema
+++ b/schemas/coordinate_systems_and_transforms.schema
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ngff.openmicroscopy.org/0.6.dev2/schemas/coordinate_systems_and_transforms.schema",
-  "title": "NGFF Coordinate Systems and Transforms",
-  "description": "Coordinate Systems and transforms for OME-NGFF",
+  "title": "Coordinate Systems and Transforms",
+  "description": "OME-Zarr coordinate systems and transforms.",
   "type": "object",
   "properties": {
     "coordinateSystems": {

--- a/schemas/coordinate_transformations.schema
+++ b/schemas/coordinate_transformations.schema
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ngff.openmicroscopy.org/0.6.dev2/schemas/coordinate_transformations.schema",
-  "title": "NGFF Coordinate Systems and Transforms",
-  "description": "Coordinate Systems and transforms for OME-NGFF",
+  "title": "Coordinate Systems and Transforms",
+  "description": "OME-Zarr Coordinate Systems and transforms.",
   "type": "array",
   "uniqueItems": true,
   "minItems": 1,

--- a/schemas/image.schema
+++ b/schemas/image.schema
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ngff.openmicroscopy.org/0.6.dev2/schemas/image.schema",
-  "title": "OME-Zarr Image",
-  "description": "The zarr.json attributes key",
+  "title": "Image",
+  "description": "OME-Zarr image.",
   "type": "object",
   "properties": {
     "ome": {

--- a/schemas/label.schema
+++ b/schemas/label.schema
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ngff.openmicroscopy.org/0.6.dev2/schemas/label.schema",
-  "title": "OME-Zarr labelled image schema",
-  "description": "The zarr.json attributes key",
+  "title": "Label",
+  "description": "OME-Zarr label.",
   "type": "object",
   "properties": {
     "ome": {

--- a/schemas/ome.schema
+++ b/schemas/ome.schema
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ngff.openmicroscopy.org/0.6.dev2/schemas/ome.schema",
-  "title": "OME-Zarr group produced by bioformats2raw to contain OME metadata",
-  "description": "The zarr.json attributes key",
+  "title": "OME",
+  "description": "OME-Zarr OME metadata.",
   "type": "object",
   "properties": {
     "ome": {

--- a/schemas/ome_zarr.schema
+++ b/schemas/ome_zarr.schema
@@ -1,6 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ngff.openmicroscopy.org/0.6.dev2/schemas/ome_zarr.schema",
+  "title": "OME-Zarr",
+  "description": "Any OME-Zarr dataset.",
   "anyOf": [
     {
       "$ref": "https://ngff.openmicroscopy.org/0.6.dev2/schemas/bf2raw.schema"

--- a/schemas/plate.schema
+++ b/schemas/plate.schema
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ngff.openmicroscopy.org/0.6.dev2/schemas/plate.schema",
-  "title": "OME-Zarr plate schema",
-  "description": "The zarr.json attributes key",
+  "title": "Plate",
+  "description": "OME-Zarr plate.",
   "type": "object",
   "properties": {
     "ome": {

--- a/schemas/well.schema
+++ b/schemas/well.schema
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ngff.openmicroscopy.org/0.6.dev2/schemas/well.schema",
-  "title": "OME-Zarr well schema",
-  "description": "JSON from OME-Zarr zarr.json",
+  "title": "Well",
+  "description": "OME-Zarr well.",
   "type": "object",
   "properties": {
     "ome": {


### PR DESCRIPTION
This tidies up the title and description fields in the schemas to make them consistent. In particular:

- As per https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#rfc.section.9.1, the titles and descriptions should relate to the metdata produced by the schemas, not the schemas themselves.
- Change NGFF > OME-Zarr

I'm hoping this is a good start to improving the schema documentation website by making the titles shorter and descriptions more descriptive.