### PR TITLE
Fix references in image schema

### DIFF
--- a/schemas/image.schema
+++ b/schemas/image.schema
@@ -9,11 +9,11 @@
       "description": "The versioned OME-Zarr Metadata namespace",
       "type": "object",
       "properties": {
-        "multiscales": {
-          "$ref": "#/$defs/multiscales"
-        },
         "omero": {
           "$ref": "#/$defs/omero"
+        },
+        "multiscales": {
+          "$ref": "#/$defs/multiscales"
         },
         "version": {
           "$ref": "https://ngff.openmicroscopy.org/0.6.dev2/schemas/_version.schema"


### PR DESCRIPTION
This references are currently broken: https://ngff-spec.readthedocs.io/en/latest/schemas/image/

Because they're references in the same schema file, they don't need to be full URLs. I'm hoping changing these to 'internal' references fixes the rendering a bit on the website.