### PR TITLE
Fix 404 link to built spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains the central [specification text](./specification.md),
 a comprehensive list of [metadata examples](./examples)
 as well as [json schemas](./schemas) to validate written ome-zarr image data.
 
-The built documentation including contribution hints can be found **[here](https://ngff-spec.readthedocs.io/en/latest/specification.html)**.
+The built documentation including contribution hints can be found **[here](https://ngff-spec.readthedocs.io/en/latest/)**.
 
 ## Conformance tests
 


### PR DESCRIPTION
Link from the README is 404. Updated to https://ngff-spec.readthedocs.io/en/latest/ which shows the spec but looks incompletely formatted:

E.g. 
```
title: Next-generation file format specification short_title: OME-Zarr

NGFF-community (link does nothing)

title: Next-generation file format specification short_title: OME-Zarr
```