### PR TITLE
Fix title formatting

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 title: Next-generation file format specification
 short_title: OME-Zarr
 ---
-(ngff-spec:spec)=
+(ngff-spec:spec:head)=
 
 **Feedback:** [Forum](https://forum.image.sc/tag/ome-ngff), [Github](https://github.com/ome/ngff/issues)
 


### PR DESCRIPTION
Mentioned by @will-moore over at #55 - the title currently doesn't render correctly. This is because I added a citation anchor at the top of the document. However, the frontmatter needs to come first:

```markdown
---
frontmatter
---
(anchor)=
```

This PR fixes it and changes the name of the anchor so it's clearer that the anchor is associated with the current development head version.