### PR TITLE
 fix 0.4: use the DOI for all versions 

### DIFF
--- a/citing.md
+++ b/citing.md
@@ -8,4 +8,4 @@ author: ""
 J. Moore, *et al*. Open Microscopy Environment Consortium, 8 February 2022.
 This edition of the specification is [https://ngff.openmicroscopy.org/0.4/](https://ngff.openmicroscopy.org/0.4/]).
 The latest edition is available at [https://ngff.openmicroscopy.org/latest/](https://ngff.openmicroscopy.org/latest/).
-[(doi:10.5281/zenodo.7972062)](https://zenodo.org/records/7972062)
+[(doi:10.5281/zenodo.4282106)](https://doi.org/10.5281/zenodo.4282106)


### PR DESCRIPTION
Updated DOI reference in citing.md

Closes https://github.com/ome/ngff/pull/204/


@jo-mueller should I also update the index.bs file? or rather should we just delete it? 