### PR TITLE
update doi and date for latest on references.bib

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -15,10 +15,10 @@
                    specifications for storing bioimaging data in the
                    cloud.
                   },
-  month        = nov,
-  year         = 2020,
+  month        = jan,
+  year         = 2025,
   publisher    = {Zenodo},
-  version      = {0.0.1},
-  doi          = {10.5281/zenodo.4282107},
+  version      = {0.5.2},
+  doi          = {10.5281/zenodo.4282106},
   url          = {https://ngff.openmicroscopy.org/latest/},
 }


### PR DESCRIPTION
Adds the DOI for "all versions", which resolves to latest (and not first)

Changed the date and version for the last release. I think that for now we will need to update that manually. 

(maybe some hooks/GH actions could do the trick in the future)  
