### PR TITLE
Fix failing `well` tests

### DIFF
--- a/tests/attributes/spec/invalid/well/forbidden_path_1.json
+++ b/tests/attributes/spec/invalid/well/forbidden_path_1.json
@@ -10,6 +10,7 @@
     "schema": {
       "id": "schemas/well.schema"
     },
+    "valid": false,
     "description": "Tests for the well JSON schema: "
   }
 }

--- a/tests/attributes/spec/invalid/well/forbidden_path_1.json
+++ b/tests/attributes/spec/invalid/well/forbidden_path_1.json
@@ -1,10 +1,13 @@
 {
-  "well": {
-    "images": [
-      {
-        "path": "."
-      }
-    ]
+  "ome": {
+    "version": "0.6.dev3",
+    "well": {
+      "images": [
+        {
+          "path": "."
+        }
+      ]
+    }
   },
   "_conformance": {
     "schema": {

--- a/tests/attributes/spec/invalid/well/forbidden_path_2.json
+++ b/tests/attributes/spec/invalid/well/forbidden_path_2.json
@@ -1,10 +1,13 @@
 {
-  "well": {
-    "images": [
-      {
-        "path": ".."
-      }
-    ]
+  "ome": {
+    "version": "0.6.dev3",
+    "well": {
+      "images": [
+        {
+          "path": ".."
+        }
+      ]
+    }
   },
   "_conformance": {
     "schema": {

--- a/tests/attributes/spec/invalid/well/forbidden_path_2.json
+++ b/tests/attributes/spec/invalid/well/forbidden_path_2.json
@@ -10,6 +10,7 @@
     "schema": {
       "id": "schemas/well.schema"
     },
+    "valid": false,
     "description": "Tests for the well JSON schema: "
   }
 }

--- a/tests/attributes/spec/invalid/well/forbidden_path_3.json
+++ b/tests/attributes/spec/invalid/well/forbidden_path_3.json
@@ -10,6 +10,7 @@
     "schema": {
       "id": "schemas/well.schema"
     },
+    "valid": false,
     "description": "Tests for the well JSON schema: "
   }
 }

--- a/tests/attributes/spec/invalid/well/forbidden_path_3.json
+++ b/tests/attributes/spec/invalid/well/forbidden_path_3.json
@@ -1,10 +1,13 @@
 {
-  "well": {
-    "images": [
-      {
-        "path": "__something"
-      }
-    ]
+  "ome": {
+    "version": "0.6.dev3",
+    "well": {
+      "images": [
+        {
+          "path": "__something"
+        }
+      ]
+    }
   },
   "_conformance": {
     "schema": {

--- a/tests/attributes/spec/invalid/well/forbidden_path_4.json
+++ b/tests/attributes/spec/invalid/well/forbidden_path_4.json
@@ -10,6 +10,7 @@
     "schema": {
       "id": "schemas/well.schema"
     },
+    "valid": false,
     "description": "Tests for the well JSON schema: "
   }
 }

--- a/tests/attributes/spec/invalid/well/forbidden_path_4.json
+++ b/tests/attributes/spec/invalid/well/forbidden_path_4.json
@@ -1,10 +1,13 @@
 {
-  "well": {
-    "images": [
-      {
-        "path": "!@#$%^&*()+={}[]"
-      }
-    ]
+  "ome": {
+    "version": "0.6.dev3",
+    "well": {
+      "images": [
+        {
+          "path": "!@#$%^&*()+={}[]"
+        }
+      ]
+    }
   },
   "_conformance": {
     "schema": {

--- a/tests/attributes/spec/valid/well/minimal_path_special_char.json
+++ b/tests/attributes/spec/valid/well/minimal_path_special_char.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev2",
+    "version": "0.6.dev3",
     "well": {
       "images": [
         {


### PR DESCRIPTION
Fixes https://github.com/ome/ngff-spec/issues/95

In the `invalid` tests, the flag `"valid": false` flag has been missing, which prevents invalid metadata being recognized as such. I also added the version tag for all the test JSON that were added by #71.