### PR TITLE
Allow coordinate systems of only type "array"

### DIFF
--- a/index.md
+++ b/index.md
@@ -1249,11 +1249,14 @@ whose value is an array containing coordinate system metadata
 The following MUST hold for all coordinate systems inside multiscales metadata.
 The length of `axes` must be between 2 and 5
 and MUST be equal to the dimensionality of the Zarr arrays storing the image data (see `datasets:path`).
-The `axes` MUST contain 2 or 3 entries of `type:space`
-and MAY contain one additional entry of `type:time`
-and MAY contain one additional entry of `type:channel` or a null / custom type.
+The `axes` MUST contain either of:
+- 2 or 3 entries of `"type":"space"`
+  and MAY contain one additional entry of `"type":"time"`
+  and MAY contain one additional entry of `"type":"channel"` or a null / custom type.
+- only entries of `"type":"array"`
+
 In addition, the entries MUST be ordered by `type` where the `time` axis must come first (if present),
-followed by the  `channel` or custom axis (if present) and the axes of type `space`.
+followed by the  `channel` or custom axis (if present) and the axes of type `space` (if present).
 If there are three spatial axes where two correspond to the image plane (`yx`)
 and images are stacked along the other (anisotropic) axis (`z`),
 the spatial axes SHOULD be ordered as `zyx`.

--- a/schemas/axes.schema
+++ b/schemas/axes.schema
@@ -24,14 +24,16 @@
         "maxContains": 3
       },
       {
-        "contains": {
-          "type": "object",
-          "properties": {
-            "type": { "const": "array" }
-          },
-          "required": ["type"]
-        },
-        "minContains": 2
+        "not": {
+          "contains": {
+            "not": {
+              "properties": {
+                "type": { "const": "array" }
+              },
+              "required": ["type"]
+            }
+          }
+        }
       }
     ],
   "minContains": 2,

--- a/tests/attributes/spec/invalid/image/invalid_axis_type2.json
+++ b/tests/attributes/spec/invalid/image/invalid_axis_type2.json
@@ -1,0 +1,54 @@
+{
+  "ome": {
+    "version": "0.6.dev3",
+    "multiscales": [
+      {
+        "coordinateSystems": [
+          {
+            "name": "intrinsic",
+            "axes": [
+              {
+                "name": "t",
+                "type": "time",
+                "unit": "second"
+              },
+              {
+                "name": "y",
+                "type": "array",
+                "unit": "micrometer"
+              },
+              {
+                "name": "x",
+                "type": "array",
+                "unit": "micrometer"
+              }
+            ]
+          }
+        ],
+        "datasets": [
+          {
+            "path": "0",
+            "coordinateTransformations": [
+              {
+                "scale": [
+                  1,
+                  1,
+                  1
+                ],
+                "type": "scale",
+                "input": "0",
+                "output": "intrinsic"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "_conformance": {
+    "schema": {
+      "id": "schemas/image.schema"
+    },
+    "valid": false
+  }
+}

--- a/tests/attributes/spec/valid/image/all_array_axes.json
+++ b/tests/attributes/spec/valid/image/all_array_axes.json
@@ -1,0 +1,45 @@
+{
+  "ome": {
+    "version": "0.6.dev3",
+    "multiscales": [
+      {
+        "coordinateSystems": [
+          {
+            "name": "intrinsic",
+            "axes": [
+              {
+                "name": "y",
+                "type": "array"
+              },
+              {
+                "name": "x",
+                "type": "array"
+              }
+            ]
+          }
+        ],
+        "datasets": [
+          {
+            "path": "0",
+            "coordinateTransformations": [
+              {
+                "scale": [
+                  1.0,
+                  1.0
+                ],
+                "input": "0",
+                "output": "intrinsic",
+                "type": "scale"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "_conformance": {
+    "schema": {
+      "id": "schemas/image.schema"
+    }
+  }
+}

--- a/version_history.md
+++ b/version_history.md
@@ -25,6 +25,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - BREAKING CHANGE: Zarr parameter storage no longer allowed for scale/translation 
   - For detailed set of changes see [complete overview](https://ngff.openmicroscopy.org/rfc/5/responses/2/index.html)
 - Updated version keys from `0.6.dev2` to `0.6.dev3` everywhere
+- specification: Relax allowed axes types in `coordinateSystems` metadata
+  to also allow coordinate systems with all axes of type `array`.
 - style: Homogeneous use of backticks in spec document
 
 ### Removed


### PR DESCRIPTION
Title. This should be the non-controversial part of #90. Until that is resolved (which may take more discussion?), this PR will allow coordinate systems to declare that they are in pixel/array coordinates rather than in physical coordinates.

This way it's possible to write coordinate transformations entirely in pixel units without having to think about flanking them inbetween scale transformations. Plus, additional transformations can *still* link between coordinate systems in pixel units and coordinate systems in physical units.

With this and #102 merged, I would cut a release (0.6.dev3) so that a bunch of metadata is finally formalized and we can go off implementing a bit more seriously.

Please note: I am *not* trying to shortcut the discussion on #90, but get this bit of the problem out of the way so we can discuss array coordinate systems in due depth without blocking people elsewhere :)

cc @bogovicj @will-moore @dstansby @btbest 