### PR TITLE
Fix link to specification text in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 NGFF is an initiative by the bioimaging community to develop imaging format specifications to
 address issues of scalability and interoperability.
 
-This repository contains the central [specification text](./specification.md),
+This repository contains the central [specification text](./index.md),
 a comprehensive list of [metadata examples](./examples)
 as well as [json schemas](./schemas) to validate written ome-zarr image data.
 


### PR DESCRIPTION
fix #111 

cc: @jo-mueller