### PR TITLE
fix: correct outputs in displacement field transform examples

### DIFF
--- a/index.md
+++ b/index.md
@@ -1159,7 +1159,7 @@ Example metadata under the attributes of the zarr array at path `coordinateTrans
     "coordinateTransformations" : [
       {
         "type" : "identity",
-        "output" : "a coordinate field transform"
+        "output" : {"name": "a coordinate field transform"}
       }
     ]
   }
@@ -1222,7 +1222,7 @@ Example metadata under the attributes of the zarr array at path `displacements` 
       {
         "type" : "scale",
         "scale" : [2, 1],
-        "output" : "a displacement field transform"
+        "output" : {"name": "a displacement field transform"}
       }
     ]
   }


### PR DESCRIPTION
Title. Currently, the examples for the displacements is lacking the correct formatting for the input/output fields that #117 introduced.