### PR TITLE
fix: correct typo and add fcollman orcid

### DIFF
--- a/authors.yml
+++ b/authors.yml
@@ -36,7 +36,8 @@ project:
       github: toloudis
       orcid: 0000-0003-2620-1233
 
-    - name: Forest Collmann
+    - name: Forrest Collman
+      orcid: 0000-0002-0280-7022
       github: fcollman
 
     - name: Nathalie Gaudreault


### PR DESCRIPTION
found when validating against acknowledgments

xref 
- https://github.com/German-BioImaging/ome-zarr-acknowledgments/issues/37