### PR TITLE
Minor formatting fixes

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -70,6 +70,9 @@ authors:
   - family-names: Barnes
     given-names: Chris
     orcid: 0000-0002-1296-7310
+  - family-names: Best
+    given-names: Benedikt T.
+    orcid: 0000-0001-6965-1117
   - family-names: Comparin
     given-names: Tommaso
     orcid: 0000-0001-6853-5931

--- a/authors.yml
+++ b/authors.yml
@@ -81,6 +81,9 @@ project:
     - name: Chris Barnes
       github: clbarnes
       orcid: 0000-0002-1296-7310
+    - name: Benedikt T. Best
+      github: btbest
+      orcid: 0000-0001-6965-1117
 
     # C
     - name: Tommaso Comparin
@@ -105,7 +108,7 @@ project:
       orcid: 0000-0002-5444-5246
     - name: Xiao Gui
       github: xgui3783
-    
+
     # H
     - name: Yaroslav O. Halchenko
       github: yarikoptic
@@ -126,7 +129,7 @@ project:
     - name: Mark Kittisopikul
       github: mkitti
       orcid: 0000-0002-9558-6248
-    
+
     # L
     - name: Talley Lambert
       github: tlambert03
@@ -144,12 +147,12 @@ project:
     - name: Juan Nunez-Iglesias
       github: jni
       orcid: 0000-0002-7239-5828
-    
+
     # O/Ö
     - name: Bugra Özdemir
       github: bugraoezdemir
       orcid: 0000-0001-9823-0581
-    
+
     # P
     - name: Giovanni Palla
       github: giovp
@@ -160,7 +163,7 @@ project:
     - name: Eric Perlman
       github: perlman
       orcid: 0000-0001-5542-1302
-    
+
     # R
     - name: Sebastian Rhode
       github: sebi06
@@ -192,7 +195,7 @@ project:
     - name: Isaac Virshup
       github: ivirshup
       orcid: 0000-0002-1710-8945
-    
+
     # W
     - name: Alan Watson
       github: alanmwatson

--- a/index.md
+++ b/index.md
@@ -313,11 +313,11 @@ The following conventions apply in this specification:
 For a more formal and in-depth definition,
 see chapter 4 and figure 4.1 of the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf).
 
-### bioformats2raw.layout
+### "bioformats2raw.layout" metadata (transitional)
 
 (bf2raw)=
 
-[=Transitional=] `"bioformats2raw.layout` metadata identifies a group which implicitly describes a series of images.
+[=Transitional=] `bioformats2raw.layout` metadata identifies a group which implicitly describes a series of images.
 The need for the collection stems from the common "multi-image file" scenario in microscopy.
 Parsers like Bio-Formats define a strict, stable ordering of the images in a single container that can be used to refer to them by other tools.
 

--- a/index.md
+++ b/index.md
@@ -1518,7 +1518,7 @@ In this example, a multiscales group containing labels is located at `labels/lab
 **`name`**
 : Each `multiscales` object SHOULD contain the field `name`.
 
-**``**type``
+**`type`**
 : Each `multiscales` object SHOULD contain the field `type`,
   which gives the type of downscaling method used to generate the multiscale image pyramid.
 

--- a/index.md
+++ b/index.md
@@ -478,7 +478,7 @@ Conforming readers:
 
 Coordinate transformations can be stored in multiple places to reflect different use cases.
 Depending on which, different constraints apply to the transformations, as described below:
-     
+
 - **Inside `multiscales > datasets`**: `coordinateTransformations` herein MUST
   - be restricted to a single `scale`, `identity` or `sequence` of a scale followed by a translation transformation.
   - in the `input` object provide `path` and omit `name`.
@@ -585,7 +585,7 @@ to do so by estimating the transformations' inverse if they choose to.
 :::
 
 ```{note}
-Exact reproducibility of pixel values for images transformed and resampled by 
+Exact reproducibility of pixel values for images transformed and resampled by
 the transformation types here may differ across implementation and is therefore
 out of the scope of this specification.
 ```
@@ -608,7 +608,7 @@ even though the coordinate systems of the two images are in physical units.
 This can be achieved by embedding the transformation into a `sequence` transformation like this:
 
 ```json
-{ "scene": 
+{ "scene":
   {
     "type": "sequence",
     "input": {"name": "intrinsic", "path": "imageA"},
@@ -678,7 +678,7 @@ In the context of multiscales metadata, this could look like this:
           ]
         }
       ],
-      "coordinateTransformations": [ 
+      "coordinateTransformations": [
         {
           "type": "scale",
           "scale": [2.0, 2.0],
@@ -951,6 +951,7 @@ these axes are typically not transformed, but must be represented in the transfo
 ```{literalinclude} examples/transformations/affine2d2d_with_channel.json
 :language: json
 ```
+:::
 
 ##### rotation
 (rotation-md)=
@@ -1065,12 +1066,12 @@ Metadata for these coordinate transforms have the following fields:
 **interpolation**
 :   The interpolation attributes MAY be provided.
     Its value indicates the interpolation to use if transforming points not on the array's discrete grid.
-    
+
     The interpolation methods listed in this specification document refer to the methods described in {cite:t}`thevenaz2000image` and are not exhaustive.
     - `nearest` for nearest neighbor interpolation (see {cite:t}`thevenaz2000image`, section 8.1),
     - `linear` for linear interpolation (default, see {cite:t}`thevenaz2000image`, section 8.2),
     - `bspline-cubic` for cubic interpolation (see {cite:t}`thevenaz2000image`, section 8.3 on "cubic B-splines).
-    
+
     Consumers SHOULD clearly communicate to users if a different interpolation method is used.
 
 ```{hint}
@@ -1104,7 +1105,7 @@ the array data referred to by `path` MUST define the following metadata fields:
   - `type`: The type of the transformation; MUST be one of [`identity`](#identity-md), [`scale`](#scale-md)
     or a [`sequence`](#sequence-md) of a [scale](#scale-md) followed by a [translation](#translation-md).
   - `output`: The name of the coordinate system defined in the `coordinateSystems` field of the array metadata.
-  
+
   *Note*: The `input` field is omitted, as it is implicitly the pixel coordinate system of the array
     (defined by the first `N` axes of the array's `coordinateSystem`).
 
@@ -1113,7 +1114,7 @@ the array data referred to by `path` MUST define the following metadata fields:
 The array at `path` MUST satisfy:
 
   - **Dimensionality**: If the input coordinate system has `N` axes, the array at location `path` MUST have `N+1` dimensions.
-  - **Vector dimension length**: 
+  - **Vector dimension length**:
     - For `coordinates` transformations, the length of the array along the `coordinate` dimension (last axis) MUST equal `M`,
       the number of axes in the output coordinate system.
     - For `displacements` transformations, the length of the array along the `displacement` dimension (last axis) MUST equal `N`,
@@ -1159,7 +1160,7 @@ Example metadata under the attributes of the zarr array at path `coordinateTrans
           { "name": "i", "type": "space", "discrete": true },
           { "name": "c", "type": "coordinate", "discrete": true }
         ]
-      } 
+      }
     ],
     "coordinateTransformations" : [
       {
@@ -1221,7 +1222,7 @@ Example metadata under the attributes of the zarr array at path `displacements` 
           { "name": "x", "type": "space", "unit" : "nanometer" },
           { "name": "d", "type": "displacement", "discrete": true }
         ]
-      } 
+      }
     ],
     "coordinateTransformations" : [
       {
@@ -1416,7 +1417,7 @@ Each object provides the following fields:
 | `coordinateTransformations` | JSON array of objects | no | Metadata about transformations that are applied to all resolution levels in the same manner. |
 | `name` | string | no | Name of the multiscale image. |
 | `type` | string | no | Downsampling method used to generate the multiscale image. |
-| `metadata` | JSON object | no | Additional metadata about the downscaling method. | 
+| `metadata` | JSON object | no | Additional metadata about the downscaling method. |
 
 **`coordinateSystems`**
 : The `coordinateSystems` field is a JSON array containing [coordinate system metadata](#coordinate-systems-md)
@@ -1663,7 +1664,7 @@ This is an example of multiscales metadata for an image group that contains a `l
 ```
 image.zarr                # Multiscale image group
 │
-├── zarr.json             # Multiscale metadata, which MAY contain a coordinate transformation 
+├── zarr.json             # Multiscale metadata, which MAY contain a coordinate transformation
 │                         # linking the "intrinsic" coordinate system of the image to the
 │                         # "intrinsic" coordinate system of the label image in the `labels` group.
 │
@@ -1997,7 +1998,7 @@ under [the following terms](https://www.w3.org/copyright/software-license-2023/)
 
 > By obtaining and/or copying this work, you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions:
 > Permission to copy, modify, and distribute this work, with or without modification, for any purpose and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the work or portions thereof, including modifications:
-> 
+>
 > The full text of this NOTICE in a location viewable to users of the redistributed or derivative work.
 > Any pre-existing intellectual property disclaimers, notices, or terms and conditions. If none exist, the W3C Software and Document Short Notice should be included.
 > Notice of any changes or modifications, through a copyright statement on the new code or document such as:


### PR DESCRIPTION
The most significant is the fix to the `rotation` heading - it ends up hidden inside the collapsible section above it at the moment:

<img width="700" height="390" alt="image" src="https://github.com/user-attachments/assets/0a03eb52-0961-4e67-925d-f7f18c849820" />

(merge note: I'd squash these)

Also sorry, just realised my IDE trimmed a bunch of trailing spaces automatically. The only meaningful change in the first commit is the added `:::`. Let me know if I should reinstate them for strict commit cleanliness 🙃 