### PR TITLE
schema: better context-dependency layering

### DIFF
--- a/schemas/coordinate_transformations.schema
+++ b/schemas/coordinate_transformations.schema
@@ -3,43 +3,22 @@
   "$id": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/coordinate_transformations.schema",
   "title": "Coordinate Transformations",
   "description": "OME-Zarr Coordinate transforms.",
-  "type": "array",
-  "uniqueItems": true,
-  "minItems": 1,
-  "items": {
-    "allOf": [
-      {
-        "$ref": "#/$defs/coordinateTransformation"
-      },
-      {
-        "type": "object",
-        "properties": {
-          "input": {
-            "allOf": [
-              {"$ref": "#/$defs/inputOutput"},
-              {"required": ["path"]}
-            ]
-          },
-          "output": {
-            "allOf": [
-              {"$ref": "#/$defs/inputOutput"},
-              {"required": ["name"]}
-            ]
-          }
-        },
-        "required": [
-          "input",
-          "output"
-        ]
-      }
-    ]
-  },
+  "$ref": "#/$defs/coordinateTransformations",
   "$defs": {
     "inputOutput": {
       "type": "object",
       "properties": {
         "name": {"type": "string"},
         "path": {"type": "string"}
+      }
+    },
+    "coordinateTransformations": {
+      "description": "JSON array of multiple OME-ZARR transformations",
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/coordinateTransformation"
       }
     },
     "coordinateTransformation": {

--- a/schemas/scene.schema
+++ b/schemas/scene.schema
@@ -15,38 +15,36 @@
                 "description": "Coordinate systems to combine with transforms to define spatial relationships"
             },
             "coordinateTransformations": {
-              "$comment": "Merge general coordinate transformations with constraints for scene metadata",
-              "allOf": [
-                {
-                  "$ref": "coordinate_transformations.schema",
-                  "description": "General coordinate transformations defining spatial relationships between coordinate systems"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "allOf": [
-                      {
-                        "properties": {
-                          "input": {
-                            "allOf": [
-                              {"$ref": "coordinate_transformations.schema#/$defs/inputOutput"},
-                              {"required": ["name"]}
-                            ]
-                          },
-                          "output": {
-                            "allOf": [
-                              {"$ref": "coordinate_transformations.schema#/$defs/inputOutput"},
-                              {"required": ["name"]}
-                            ]
-                          }
-                        }
-                      }
-                    ]
+              "$comment": "Coordinate transformations defining spatial relationships between coordinate systems",
+              "type": "array",
+              "items": {
+                "allOf": [
+                  {
+                    "$ref": "coordinate_transformations.schema#/$defs/coordinateTransformation"
                   },
-                  "description": "Constrained input/output for coordinate transformations in scene metadata"
-                }
-              ]
-                
+                  {
+                    "type": "object",
+                    "properties": {
+                      "input": {
+                        "allOf": [
+                          {"$ref": "coordinate_transformations.schema#/$defs/inputOutput"},
+                          {"required": ["name"]}
+                        ]
+                      },
+                      "output": {
+                        "allOf": [
+                          {"$ref": "coordinate_transformations.schema#/$defs/inputOutput"},
+                          {"required": ["name"]}
+                        ]
+                      }
+                    },
+                    "required": ["input", "output"]
+                  }
+                ]
+              },
+              "minItems": 1,
+              "uniqueItems": true,
+              "description": "Coordinate transformations defining spatial relationships between coordinate systems with scene-specific constraints"
             },
             "arrayCoordinateSystem": {
               "type": "object",

--- a/tests/attributes/spec/valid/scene/scene.json
+++ b/tests/attributes/spec/valid/scene/scene.json
@@ -1,0 +1,71 @@
+{
+  "ome": {
+    "version": "0.6.dev4",
+    "scene": {
+      "coordinateTransformations": [
+        {
+          "input": {"path": "4995115_cropped_400_100_400_400_rot10.zarr", "name": "rotated"},
+          "output": {"name": "translated_x50"},
+          "name": "translate_tile_to_stitched_position",
+          "type": "translation",
+          "translation": [
+            0,
+            0,
+            30.608878192215265,
+            11.21775638443053
+          ]
+        },
+        {
+          "input": {"path": "4995115_cropped_700_700_400_400_rot45.zarr", "name": "rotated"},
+          "output": {"name": "translated_x50"},
+          "name": "translate_tile_to_stitched_position",
+          "type": "translation",
+          "translation": [
+            0,
+            0,
+            91.8266345766458,
+            41.8266345766458
+          ]
+        },
+        {
+          "input": {"name": "translated_x50"},
+          "output": {"path": "4995115_full.zarr", "name": "physical"},
+          "name": "translate_tile_to_stitched_position",
+          "type": "translation",
+          "translation": [
+            0,
+            0,
+            0,
+            50
+          ]
+        }
+      ],
+      "coordinateSystems": [
+        {
+          "name": "translated_x50",
+          "axes": [
+            {
+              "name": "c",
+              "type": "channel"
+            },
+            {
+              "name": "z",
+              "type": "space",
+              "unit": "micrometer"
+            },
+            {
+              "name": "y",
+              "type": "space",
+              "unit": "micrometer"
+            },
+            {
+              "name": "x",
+              "type": "space",
+              "unit": "micrometer"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Fixes #149 

Essentially, in the root of where coordinate transformations were previously defined, additional constraints for the presence of `path` and `name` in the `input` and `output` fields of transforms were introduced. However, since depending on the context either or both of `name` and `path` are required, this constraint should only be added in the respective context. This led to a validation error in the scene context, where `name` is always required and `path` is optional.