### PR TITLE
Broaden scope of mapAxis

### DIFF
--- a/examples/transformations/mapAxis2.json
+++ b/examples/transformations/mapAxis2.json
@@ -15,7 +15,7 @@
     { 
       "name": "projection up",
       "type": "mapAxis", 
-      "mapAxis": [1, 1, 0],
+      "mapAxis": [null, 0, 1],
       "input": {"name": "in"},
       "output": {"name": "out_up"} 
     }

--- a/index.md
+++ b/index.md
@@ -741,18 +741,20 @@ y = j
 ##### mapAxis
 (mapAxis-md)=
 
-`mapAxis` transformations describe axis permutations as a transpose vector of integers.
+`mapAxis` transformations describe axis permutations, adding or dropping of axes as a vector of integers or nulls.
 Transformations MUST include a `mapAxis` field
-whose value is an array of integers that specifies the new ordering in terms of indices of the old order.
-The length of the array MUST equal the number of dimensions in both the input and output coordinate systems.
+whose value is an array of unique integers or nulls that specifies the new ordering in terms of indices of the old order.
 Each integer in the array MUST be a valid zero-based index into the input coordinate system's axes
 (i.e., between 0 and N-1 for an N-dimensional input).
-Each index MUST appear exactly once in the array.
 The value at position `i` in the array indicates which input axis becomes the `i`-th output axis.
-`mapAxis` transforms are invertible.
+`mapAxis` transforms are invertible if the array contains no nulls
+and its length corresponds to the number of dimensions in both the input and output coordinate systems.
+
+If the value `null` is used in a `mapAxis` transformation,
+this corresponds to adding the value zero in the coordinate vector at the position of the null.
 
 **mapAxis**
-: The axis permutation stored as a JSON array of integers.
+: The axis permutation stored as a JSON array of integers or nulls.
 
 
 :::{dropdown} Example 1
@@ -792,9 +794,9 @@ x = b
 and the `projection_up` transformation defines the function:
 
 ```
-x = a
-y = b
-z = b
+x = b
+y = a
+z = 0
 ```
 :::
 

--- a/schemas/coordinate_transformations.schema
+++ b/schemas/coordinate_transformations.schema
@@ -119,14 +119,20 @@
         "mapAxis": {
           "type": "array",
           "items": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 4
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 4
+              },
+              {
+                "type": "null"
+              }
+            ]            
           },
-          "minItems": 2,
           "maxItems": 5,
           "uniqueItems": true,
-          "description": "An array of integers representing the new axis order as zero-based indices of the input axes."
+          "description": "An array of integers or nulls representing the new axis order as zero-based indices of the input axes."
         }
       },
       "required": [

--- a/tests/attributes/spec/valid/transforms/mapAxis_up.json
+++ b/tests/attributes/spec/valid/transforms/mapAxis_up.json
@@ -1,0 +1,133 @@
+{
+  "ome": {
+    "version": "0.6.dev4",
+    "multiscales": [
+      {
+        "name": "multiscales",
+        "coordinateSystems": [
+          {
+            "name": "world",
+            "axes": [
+              {
+                "type": "space",
+                "name": "z",
+                "unit": "micrometer",
+                "discrete": false
+              },
+              {
+                "type": "space",
+                "name": "y",
+                "unit": "micrometer",
+                "discrete": false
+              },
+              {
+                "type": "space",
+                "name": "x",
+                "unit": "micrometer",
+                "discrete": false
+              }
+            ]
+          },
+          {
+            "name": "physical",
+            "axes": [
+              {
+                "type": "space",
+                "name": "y",
+                "unit": "micrometer",
+                "discrete": false
+              },
+              {
+                "type": "space",
+                "name": "x",
+                "unit": "micrometer",
+                "discrete": false
+              }
+            ]
+          }
+        ],
+        "datasets": [
+          {
+            "path": "s0",
+            "coordinateTransformations": [
+              {
+                "type": "sequence",
+                "output": {"name": "physical"},
+                "input": {"path": "s0"},
+                "name": "scale0_to_physical",
+                "transformations": [
+                  {
+                    "type": "scale",
+                    "scale": [1, 1]
+                  },
+                  {
+                    "type": "translation",
+                    "translation": [0, 0]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "path": "s1",
+            "coordinateTransformations": [
+              {
+                "type": "sequence",
+                "output": {"name": "physical"},
+                "input": {"path": "s1"},
+                "name": "scale1_to_physical",
+                "transformations": [
+                  {
+                    "type": "scale",
+                    "scale": [2, 2]
+                  },
+                  {
+                    "type": "translation",
+                    "translation": [0.7071, 0.7071]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "path": "s2",
+            "coordinateTransformations": [
+              {
+                "type": "sequence",
+                "output": {"name": "physical"},
+                "input": {"path": "s2"},
+                "name": "scale2_to_physical",
+                "transformations": [
+                  {
+                    "type": "scale",
+                    "scale": [4, 4]
+                  },
+                  {
+                    "type": "translation",
+                    "translation": [2.1213, 2.1213]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "coordinateTransformations": [
+          {
+            "type": "mapAxis",
+            "name": "physical-to-world",
+            "input": {"name": "physical"},
+            "output": {"name": "world"},
+            "mapAxis": [null, 0, 1]
+          }
+        ]
+      }
+    ]
+  },
+    "_conformance": {
+      "schema": {
+      "id": "schemas/image.schema"
+      },
+      "description": "Tests for a JSON document with a mapAxis transformation",
+      "valid": true
+  }
+}


### PR DESCRIPTION
Alternative to #130 : THis is a fairly small change that broadens the scope of the `mapAxis` transform to not purely do permutations, but to be able to express up-/down-projections as well.