### PR TITLE
refactor: use camelCase in byDimension transform

### DIFF
--- a/examples/transformations/byDimension1.json
+++ b/examples/transformations/byDimension1.json
@@ -20,16 +20,16 @@
             "type": "translation",
             "translation": [-1.0]
           },
-          "input_axes": [1],
-          "output_axes": [1]
+          "inputAxes": [1],
+          "outputAxes": [1]
         },
         {
           "transformation": {
             "type": "scale",
             "scale": [2.0]
           },
-          "input_axes": [0],
-          "output_axes": [0]
+          "inputAxes": [0],
+          "outputAxes": [0]
         }
       ]
     }

--- a/examples/transformations/byDimension2.json
+++ b/examples/transformations/byDimension2.json
@@ -29,16 +29,16 @@
             "type": "translation",
             "translation": [ 0.5, 1.5 ]
           },
-          "input_axes": [ 3, 2 ],
-          "output_axes": [ 1, 2 ]
+          "inputAxes": [ 3, 2 ],
+          "outputAxes": [ 1, 2 ]
         },
         {
           "transformation": {
             "type": "scale",
             "scale": [ 2 ]
           },
-          "input_axes": [ 1 ],
-          "output_axes": [ 0 ]
+          "inputAxes": [ 1 ],
+          "outputAxes": [ 0 ]
         }
       ]
     }

--- a/examples/transformations/byDimensionInvalid1.json
+++ b/examples/transformations/byDimensionInvalid1.json
@@ -20,16 +20,16 @@
             "type": "translation",
             "translation": [-1.0]
           },
-          "input_axes": [1],
-          "output_axes": [2]
+          "inputAxes": [1],
+          "outputAxes": [2]
         },
         {
           "transformation": {
             "type": "scale",
             "scale": [2.0]
           },
-          "input_axes": [0],
-          "output_axes": [2]
+          "inputAxes": [0],
+          "outputAxes": [2]
         }
       ]
     }

--- a/examples/transformations/byDimensionInvalid2.json
+++ b/examples/transformations/byDimensionInvalid2.json
@@ -21,16 +21,16 @@
             "type": "translation",
             "translation": [-1.0]
           },
-          "input_axes": [1],
-          "output_axes": [1]
+          "inputAxes": [1],
+          "outputAxes": [1]
         },
         {
           "transformation": {
             "type": "scale",
             "scale": [2.0]
           },
-          "input_axes": [1],
-          "output_axes": [1]
+          "inputAxes": [1],
+          "outputAxes": [1]
         }
       ]
     }

--- a/examples/transformations/byDimensionXarray.json
+++ b/examples/transformations/byDimensionXarray.json
@@ -24,14 +24,14 @@
         {
           "type": "coordinates",
           "path": "xCoordinates",
-          "input_axes": [ 0 ],
-          "output_axes": [ 0 ]
+          "inputAxes": [ 0 ],
+          "outputAxes": [ 0 ]
         },
         {
           "type": "coordinates",
           "path": "yCoordinates",
-          "input_axes": [ 1 ],
-          "output_axes": [ 1 ]
+          "inputAxes": [ 1 ],
+          "outputAxes": [ 1 ]
         }
       ]
     }

--- a/examples/transformations/sequenceSubspace1.json
+++ b/examples/transformations/sequenceSubspace1.json
@@ -18,14 +18,14 @@
         {
             "type" : "coordinates",
             "path" : "/coordinates",
-            "input_axes" : ["i"],
-            "output_axes" : ["x"]
+            "inputAxes" : ["i"],
+            "outputAxes" : ["x"]
         },
         {
             "type" : "scale",
             "scale" : [2.0],
-            "input_axes" : ["j"],
-            "output_axes" : ["y"]
+            "inputAxes" : ["j"],
+            "outputAxes" : ["y"]
         }
       ]
     }

--- a/examples/transformations/xarrayLike.json
+++ b/examples/transformations/xarrayLike.json
@@ -14,16 +14,16 @@
             "type": "coordinates",
             "path": "/xCoordinates"
           },
-          "input_axes" : [0],
-          "output_axes" : [0]
+          "inputAxes" : [0],
+          "outputAxes" : [0]
         },
         {
           "transformation": {
             "type": "coordinates",
             "path": "/yCoordinates"
           },
-          "input_axes" : [1],
-          "output_axes" : [1]
+          "inputAxes" : [1],
+          "outputAxes" : [1]
         }
       ]
     }

--- a/index.md
+++ b/index.md
@@ -430,7 +430,7 @@ The following transformations are supported:
 | [`displacements`](#coordinates-displacements-md) | `"path":str` <br> `"interpolation":str` | Displacement field transformation located at `path`. |
 | [`coordinates`](#coordinates-displacements-md) | `"path":str` <br> `"interpolation":str` | Coordinate field transformation located at `path`. |
 | [`bijection`](#bijection-md) | `"forward":Transformation`<br>`"inverse":Transformation` | An invertible transformation providing an explicit forward transformation and its inverse. |
-| [`byDimension`](#bydimension-md) | `"transformations":List[Transformation]`.<br>Transformations in the array MUST have<br>`"input_axes": List[number]`, <br> and `"output_axes": List[number]` | A high dimensional transformation using lower dimensional transformations on subsets of dimensions. |
+| [`byDimension`](#bydimension-md) | `"transformations":List[Transformation]`.<br>Transformations in the array MUST have<br>`"inputAxes": List[number]`, <br> and `"outputAxes": List[number]` | A high dimensional transformation using lower dimensional transformations on subsets of dimensions. |
 
 Implementations SHOULD prefer to store transformations as a sequence of less expressive transformations where possible
 (e.g., sequence[translation, rotation], instead of affine transformation with translation/rotation).
@@ -1146,14 +1146,14 @@ using lower dimensional transformations on subsets of dimensions.
 
 **transformations**
 : MUST be an array of objects where each object MUST contain
-  the fields `input_axes`, `output_axes` and `transformation`.
-  The values of `input_axes` and `output_axes` are arrays of integers.
+  the fields `inputAxes`, `outputAxes` and `transformation`.
+  The values of `inputAxes` and `outputAxes` are arrays of integers.
   The integer values in these arrays correspond to the axis indices in the `byDimension`'s or its parent's
   `input` and `output` coordinate systems, respectively.
   The value of `transformation` is a valid transformation object.
   Every axis index in the parent byDimension's `output` coordinate system
-  MUST appear in exactly one child transformation's `output_axes` array.
-  The `input_axes` and `output_axes` arrays of each item
+  MUST appear in exactly one child transformation's `outputAxes` array.
+  The `inputAxes` and `outputAxes` arrays of each item
   MUST have the same length as that transformation's parameter arrays.
 
 :::{dropdown} Example 1
@@ -1182,7 +1182,7 @@ This is an **invalid** `byDimension` transform:
 :language: json
 ```
 
-It is invalid because the `output_axes` arrays of both transformations refer to the index of an axis that doesn't exist.
+It is invalid because the `outputAxes` arrays of both transformations refer to the index of an axis that doesn't exist.
 The coordinate system has two axes (indices `0` and `1`), but the transformations refers to index `2`.
 
 :::
@@ -1195,7 +1195,7 @@ Another **invalid** `byDimension` transform:
 :language: json
 ```
 
-This transformation is invalid because the output axis `x` appears in more than one transformation in the `transformations` array.
+This transformation is invalid because the output axis `[1]` appears in more than one transformation in the `transformations` array.
 :::
 
 ##### bijection

--- a/schemas/coordinate_transformations.schema
+++ b/schemas/coordinate_transformations.schema
@@ -319,14 +319,14 @@
               "transformation": {
                 "$ref": "#/$defs/coordinateTransformation"
               },
-              "input_axes": {
+              "inputAxes": {
                 "type": "array",
                 "items": {
                   "type": "number"
                 },
                 "description": "Names of the input axes for this transformation."
               },
-              "output_axes": {
+              "outputAxes": {
                 "type": "array",
                 "items": {
                   "type": "number"
@@ -336,8 +336,8 @@
             },
             "required": [
               "transformation",
-              "input_axes",
-              "output_axes"
+              "inputAxes",
+              "outputAxes"
             ]
           }
         }

--- a/tests/attributes/spec/invalid/transforms/bad_byDimension_wrong axes_type.json
+++ b/tests/attributes/spec/invalid/transforms/bad_byDimension_wrong axes_type.json
@@ -61,14 +61,14 @@
 						"transformations": [
 							{
 								"type": "scale",
-								"input_axes": ["x"],
-								"output_axes": ["x"],
+								"inputAxes": ["x"],
+								"outputAxes": ["x"],
 								"scale": [2]
 							},
 							{
 								"type": "translation",
-								"input_axes": ["y"],
-								"output_axes": ["y"],
+								"inputAxes": ["y"],
+								"outputAxes": ["y"],
 								"translation": [-10]
 							}
 						],

--- a/tests/attributes/spec/valid/image/multiscales_transform_additional_transforms.json
+++ b/tests/attributes/spec/valid/image/multiscales_transform_additional_transforms.json
@@ -121,16 +121,16 @@
 											"type": "scale",
 											"scale": [2]
 										},
-										"output_axes": [0],
-										"input_axes": [0]
+										"outputAxes": [0],
+										"inputAxes": [0]
 									},
 									{
 										"transformation": {
 											"type": "translation",
 											"translation": [-10]
 										},
-										"output_axes": [1],
-										"input_axes": [1]
+										"outputAxes": [1],
+										"inputAxes": [1]
 									}
 								],
 								"name": "transform-name"

--- a/tests/attributes/spec/valid/transforms/byDimension.json
+++ b/tests/attributes/spec/valid/transforms/byDimension.json
@@ -62,16 +62,16 @@
                   "type": "scale",
                   "scale": [2]
                 },
-                "output_axes": [0],
-                "input_axes": [0]
+                "outputAxes": [0],
+                "inputAxes": [0]
               },
               {
                 "transformation": {
                   "type": "translation",
                   "translation": [-10]
                 },
-                "output_axes": [1],
-                "input_axes": [1]
+                "outputAxes": [1],
+                "inputAxes": [1]
                 
               }
             ],

--- a/version_history.md
+++ b/version_history.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Displacements and coordinate transformations are now required
 to store the vector field as a normal multiscale group with the same metadata as other multiscales. Decided at EMBL Hackathon 06/2026 by RFC5 developers.
 - Additional requirements for displacement or coordinate axis `"type"` and `discrete` fields (now required).
+- Changed the `input_axes` and `output_axes` fields in the `byDimension` transform to camelCase (`inputAxes` and `outputAxes`)
 
 ### Added
 


### PR DESCRIPTION
@will-moore @d-v-b @DragaDoncila 

Because it came up in [this thread](https://github.com/ome/ngff-spec/pull/130#discussion_r3499342323), this PR changes the convention for the `input_axes` field from snake_case to camelCase (`inputAxes` and `outputAxes`)