### PR TITLE
0.6rc0 release bump

### DIFF
--- a/_version.py
+++ b/_version.py
@@ -1,1 +1,1 @@
-__version__ = '0.6.dev4'
+__version__ = '0.6rc0'

--- a/examples/bf2raw/image.json
+++ b/examples/bf2raw/image.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "bioformats2raw.layout": 3
     }
   }

--- a/examples/bf2raw/plate.json
+++ b/examples/bf2raw/plate.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "bioformats2raw.layout": 3,
       "plate": {
         "columns": [

--- a/examples/label_strict/colors_properties.json
+++ b/examples/label_strict/colors_properties.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/examples/multiscales_strict/multiscales_example.json
+++ b/examples/multiscales_strict/multiscales_example.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "name": "example",

--- a/examples/multiscales_strict/multiscales_example_relative.json
+++ b/examples/multiscales_strict/multiscales_example_relative.json
@@ -1,7 +1,7 @@
 {
   "multiscales": [
     {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "name": "example",
       "coordinateSystems" : [
         {

--- a/examples/multiscales_strict/multiscales_reference_to_label.json
+++ b/examples/multiscales_strict/multiscales_reference_to_label.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "name": "Image",

--- a/examples/multiscales_strict/multiscales_transformations.json
+++ b/examples/multiscales_strict/multiscales_transformations.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/examples/ome/series-2.json
+++ b/examples/ome/series-2.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "series": ["0", "1"]
     }
   }

--- a/examples/plate_strict/plate_2wells.json
+++ b/examples/plate_strict/plate_2wells.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "acquisitions": [
           {

--- a/examples/plate_strict/plate_6wells.json
+++ b/examples/plate_strict/plate_6wells.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "acquisitions": [
           {

--- a/examples/scene/scene_registration.json
+++ b/examples/scene/scene_registration.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "scene": {
         "coordinateTransformations": [
           {

--- a/examples/scene/scene_stitching.json
+++ b/examples/scene/scene_stitching.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "scene": {
         "coordinateTransformations": [
           {

--- a/examples/subspace/subspacePermute.json
+++ b/examples/subspace/subspacePermute.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "name": "multiscales",

--- a/examples/transformations/displacements/displacement_field.json
+++ b/examples/transformations/displacements/displacement_field.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "name": "the_dfield",
     "multiscales": [
       {

--- a/examples/transformations/displacements/multiscales.json
+++ b/examples/transformations/displacements/multiscales.json
@@ -1,5 +1,5 @@
 {
-  "ome": "0.6.dev4",
+  "ome": "0.6rc0",
   "name": "some_image",
   "multiscales": [
     {

--- a/examples/well_strict/well_2fields.json
+++ b/examples/well_strict/well_2fields.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "well": {
         "images": [
           {

--- a/examples/well_strict/well_4fields.json
+++ b/examples/well_strict/well_4fields.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "well": {
         "images": [
           {

--- a/index.md
+++ b/index.md
@@ -4,8 +4,8 @@ short_title: OME-Zarr
 authors: " "
 ---
 
-# 🚧 Dev: 0.6.dev4 🚧
-(ngff-spec:spec:0.6.dev4)=
+# 🚧 Dev: 0.6rc0 🚧
+(ngff-spec:spec:0.6rc0)=
 
 **Feedback:** [Forum](https://forum.image.sc/tag/ome-ngff), [Github](https://github.com/ome/ngff/issues)
 
@@ -29,7 +29,7 @@ All specifications are submitted to the <https://image.sc> community for review.
 
 ## Status of This Document
 
-The working title version of this specification is 0.6.dev4.
+The working title version of this specification is 0.6rc0.
 Migration scripts will be provided between numbered versions.
 Data written with these latest changes (an "editor's draft") will not necessarily be supported.
 
@@ -189,14 +189,14 @@ The OME-Zarr Metadata is stored in the various `zarr.json` files throughout the 
 The OME-Zarr Metadata version MUST be consistent within a hierarchy.
 
 The group `attributes` MUST contain a key `ome`. The value of the `ome` key MUST be a JSON
-object that MUST contain a `version` key, the value of which MUST be a string specifying the version of the OME-Zarr specification defined by [this document](ngff-spec:spec:0.6.dev4).
+object that MUST contain a `version` key, the value of which MUST be a string specifying the version of the OME-Zarr specification defined by [this document](ngff-spec:spec:0.6rc0).
 
 ```jsonc
 {
   // ...
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       // ...
     }
   }
@@ -1541,7 +1541,7 @@ The `zarr.json` under the `labels` group contains a JSON object with the key `la
 {
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "labels": [
         "cell_segmentation"
       ]

--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ short_title: OME-Zarr
 authors: " "
 ---
 
-# 🚧 Dev: 0.6rc0 🚧
+# Version 0.6rc0
 (ngff-spec:spec:0.6rc0)=
 
 **Feedback:** [Forum](https://forum.image.sc/tag/ome-ngff), [Github](https://github.com/ome/ngff/issues)
@@ -18,9 +18,8 @@ authors: " "
 ## Abstract
 
 ```{warning}
-This is **not** the released version of the ngff-specification.
-It is a work-in-progress document.
-Upon release, this warning will be removed and the version number in the document updated.
+This is the release candidate for version 0.6rc0 of the ngff-specification.
+Upon release of 0.6, this warning will be removed and the version number in the document updated.
 
 ```
 

--- a/schemas/_version.schema
+++ b/schemas/_version.schema
@@ -1,10 +1,10 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/_version.schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6rc0/schemas/_version.schema",
   "title": "OME-Zarr version",
   "description": "OME-Zarr version.",
   "type": "string",
   "enum": [
-    "0.6.dev4"
+    "0.6rc0"
   ]
 }

--- a/schemas/axes.schema
+++ b/schemas/axes.schema
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/axes.schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6rc0/schemas/axes.schema",
   "title": "Axes",
   "description": "OME-Zarr Axes.",
   "type": "array",

--- a/schemas/bf2raw.schema
+++ b/schemas/bf2raw.schema
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/bf2raw.schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6rc0/schemas/bf2raw.schema",
   "title": "bioformats2raw",
   "description": "OME-Zarr bioformats2raw metadata.",
   "type": "object",
@@ -17,7 +17,7 @@
           ]
         },
         "version": {
-          "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/_version.schema"
+          "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/_version.schema"
         }
       },
       "required": [

--- a/schemas/coordinate_systems.schema
+++ b/schemas/coordinate_systems.schema
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/coordinate_systems.schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6rc0/schemas/coordinate_systems.schema",
   "title": "Coordinate systems",
   "description": "OME-Zarr coordinate system.",
   "type": "array",

--- a/schemas/coordinate_transformations.schema
+++ b/schemas/coordinate_transformations.schema
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/coordinate_transformations.schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6rc0/schemas/coordinate_transformations.schema",
   "title": "Coordinate Transformations",
   "description": "OME-Zarr Coordinate transforms.",
   "type": "array",

--- a/schemas/image.schema
+++ b/schemas/image.schema
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/image.schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6rc0/schemas/image.schema",
   "title": "Image",
   "description": "OME-Zarr image.",
   "type": "object",
@@ -16,7 +16,7 @@
           "$ref": "#/$defs/multiscales"
         },
         "version": {
-          "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/_version.schema"
+          "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/_version.schema"
         }
       },
       "required": [
@@ -56,14 +56,14 @@
                         "description": "A single scale transformation",
                         "allOf": [
                           {
-                            "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/coordinate_transformations.schema#/$defs/scale"
+                            "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/coordinate_transformations.schema#/$defs/scale"
                           },
                           {
                             "type": "object",
                             "properties": {
                               "input": {
                                 "allOf": [
-                                  {"$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/coordinate_transformations.schema#/$defs/inputOutput"},
+                                  {"$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/coordinate_transformations.schema#/$defs/inputOutput"},
                                   {
                                     "required": ["path"]
                                   }
@@ -71,7 +71,7 @@
                               },
                               "output": {
                                 "allOf": [
-                                  {"$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/coordinate_transformations.schema#/$defs/inputOutput"},
+                                  {"$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/coordinate_transformations.schema#/$defs/inputOutput"},
                                   {
                                     "required": ["name"]
                                   }
@@ -86,13 +86,13 @@
                       {
                         "description": "A single identity transformation",
                         "allOf": [
-                          {"$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/coordinate_transformations.schema#/$defs/identity"},
+                          {"$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/coordinate_transformations.schema#/$defs/identity"},
                           {
                             "type": "object",
                             "properties": {
                               "input": {
                                 "allOf": [
-                                  {"$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/coordinate_transformations.schema#/$defs/inputOutput"},
+                                  {"$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/coordinate_transformations.schema#/$defs/inputOutput"},
                                   {
                                     "required": ["path"]
                                   }
@@ -100,7 +100,7 @@
                               },
                               "output": {
                                 "allOf": [
-                                  {"$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/coordinate_transformations.schema#/$defs/inputOutput"},
+                                  {"$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/coordinate_transformations.schema#/$defs/inputOutput"},
                                   {
                                     "required": ["name"]
                                   }
@@ -121,8 +121,8 @@
                             "type": "array",
                             "items": {
                               "oneOf": [
-                                {"$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/coordinate_transformations.schema#/$defs/scale"},
-                                {"$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/coordinate_transformations.schema#/$defs/translation"}
+                                {"$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/coordinate_transformations.schema#/$defs/scale"},
+                                {"$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/coordinate_transformations.schema#/$defs/translation"}
                               ]
                             },
                             "minItems": 2,
@@ -130,7 +130,7 @@
                           },
                           "input": {
                             "allOf": [
-                              {"$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/coordinate_transformations.schema#/$defs/inputOutput"},
+                              {"$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/coordinate_transformations.schema#/$defs/inputOutput"},
                               {
                                 "required": ["path"]
                               }
@@ -138,7 +138,7 @@
                           },
                           "output": {
                             "allOf": [
-                              {"$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/coordinate_transformations.schema#/$defs/inputOutput"},
+                              {"$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/coordinate_transformations.schema#/$defs/inputOutput"},
                               {
                                 "required": ["name"]
                               }
@@ -165,7 +165,7 @@
             "type": "array",
             "minItems": 1,
             "items": {
-              "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/coordinate_systems.schema#/$defs/coordinateSystem"
+              "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/coordinate_systems.schema#/$defs/coordinateSystem"
             }
           },
           "coordinateTransformations": {
@@ -174,7 +174,7 @@
             "items": {
               "allOf": [
                 {
-                  "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/coordinate_transformations.schema#/$defs/coordinateTransformation",
+                  "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/coordinate_transformations.schema#/$defs/coordinateTransformation",
                   "description": "Parameters of any possible transform"
                 },
                 {

--- a/schemas/label.schema
+++ b/schemas/label.schema
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/label.schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6rc0/schemas/label.schema",
   "title": "Label",
   "description": "OME-Zarr label.",
   "type": "object",
@@ -13,7 +13,7 @@
           "$ref": "#/$defs/image-label"
         },
         "version": {
-          "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/_version.schema"
+          "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/_version.schema"
         }
       },
       "required": [

--- a/schemas/ome.schema
+++ b/schemas/ome.schema
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/ome.schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6rc0/schemas/ome.schema",
   "title": "OME",
   "description": "OME-Zarr OME metadata.",
   "type": "object",
@@ -18,7 +18,7 @@
           "minContains": 1
         },
         "version": {
-          "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/_version.schema"
+          "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/_version.schema"
         }
       },
       "required": [

--- a/schemas/ome_zarr.schema
+++ b/schemas/ome_zarr.schema
@@ -1,29 +1,29 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/ome_zarr.schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6rc0/schemas/ome_zarr.schema",
   "title": "OME-Zarr",
   "description": "Any OME-Zarr dataset.",
   "anyOf": [
     {
-      "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/bf2raw.schema"
+      "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/bf2raw.schema"
     },
     {
-      "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/image.schema"
+      "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/image.schema"
     },
     {
-      "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/label.schema"
+      "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/label.schema"
     },
     {
-      "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/ome.schema"
+      "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/ome.schema"
     },
     {
-      "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/plate.schema"
+      "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/plate.schema"
     },
     {
-      "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/well.schema"
+      "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/well.schema"
     },
     {
-      "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/scene.schema"
+      "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/scene.schema"
     }
   ]
 }

--- a/schemas/plate.schema
+++ b/schemas/plate.schema
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/plate.schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6rc0/schemas/plate.schema",
   "title": "Plate",
   "description": "OME-Zarr plate.",
   "type": "object",
@@ -138,7 +138,7 @@
           ]
         },
         "version": {
-          "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/_version.schema"
+          "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/_version.schema"
         }
       },
       "required": [

--- a/schemas/scene.schema
+++ b/schemas/scene.schema
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/scene.schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6rc0/schemas/scene.schema",
   "title": "Scene",
   "description": "Scene metadata combining coordinate systems and coordinate transformations to define spatial relationships",
   "type": "object",
@@ -9,7 +9,7 @@
       "type": "object",
       "properties": {
         "version": {
-          "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/_version.schema"
+          "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/_version.schema"
         },
         "scene":{
           "properties": {

--- a/schemas/strict_axes.schema
+++ b/schemas/strict_axes.schema
@@ -1,11 +1,11 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/strict_axes.schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6rc0/schemas/strict_axes.schema",
   "title": "NGFF Strict Axes",
   "description": "JSON from OME-NGFF .zattrs",
   "allOf": [
     {
-      "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/axes.schema"
+      "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/axes.schema"
     },
     {
       "items": {

--- a/schemas/strict_coordinate_systems.schema
+++ b/schemas/strict_coordinate_systems.schema
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/strict_coordinate_systems.schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6rc0/schemas/strict_coordinate_systems.schema",
   "allOf" : [
     {
       "$ref": "coordinate_systems.schema"

--- a/schemas/strict_image.schema
+++ b/schemas/strict_image.schema
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/strict_image.schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6rc0/schemas/strict_image.schema",
   "allOf": [
     {
-      "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/image.schema"
+      "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/image.schema"
     },
     {
       "properties": {

--- a/schemas/strict_label.schema
+++ b/schemas/strict_label.schema
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/strict_label.schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6rc0/schemas/strict_label.schema",
   "allOf": [
     {
-      "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/label.schema"
+      "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/label.schema"
     },
     {
       "properties": {

--- a/schemas/strict_ome_zarr.schema
+++ b/schemas/strict_ome_zarr.schema
@@ -1,24 +1,24 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/strict_ome_zarr.schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6rc0/schemas/strict_ome_zarr.schema",
   "anyOf": [
     {
-      "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/bf2raw.schema"
+      "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/bf2raw.schema"
     },
     {
-      "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/strict_image.schema"
+      "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/strict_image.schema"
     },
     {
-      "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/strict_label.schema"
+      "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/strict_label.schema"
     },
     {
-      "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/ome.schema"
+      "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/ome.schema"
     },
     {
-      "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/strict_plate.schema"
+      "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/strict_plate.schema"
     },
     {
-      "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/strict_well.schema"
+      "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/strict_well.schema"
     }
   ]
 }

--- a/schemas/strict_plate.schema
+++ b/schemas/strict_plate.schema
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/strict_plate.schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6rc0/schemas/strict_plate.schema",
   "allOf": [
     {
-      "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/plate.schema"
+      "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/plate.schema"
     },
     {
       "properties": {

--- a/schemas/strict_well.schema
+++ b/schemas/strict_well.schema
@@ -1,5 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/strict_well.schema",
-  "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/well.schema"
+  "$id": "https://ngff.openmicroscopy.org/0.6rc0/schemas/strict_well.schema",
+  "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/well.schema"
 }

--- a/schemas/well.schema
+++ b/schemas/well.schema
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/well.schema",
+  "$id": "https://ngff.openmicroscopy.org/0.6rc0/schemas/well.schema",
   "title": "Well",
   "description": "OME-Zarr well.",
   "type": "object",
@@ -48,7 +48,7 @@
           ]
         },
         "version": {
-          "$ref": "https://ngff.openmicroscopy.org/0.6.dev4/schemas/_version.schema"
+          "$ref": "https://ngff.openmicroscopy.org/0.6rc0/schemas/_version.schema"
         }
       },
       "required": [

--- a/tests/attributes/spec/invalid/image/duplicate_axes.json
+++ b/tests/attributes/spec/invalid/image/duplicate_axes.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/duplicate_scale.json
+++ b/tests/attributes/spec/invalid/image/duplicate_scale.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/empty_transformations.json
+++ b/tests/attributes/spec/invalid/image/empty_transformations.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/invalid_axes_count.json
+++ b/tests/attributes/spec/invalid/image/invalid_axes_count.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/invalid_axis_type.json
+++ b/tests/attributes/spec/invalid/image/invalid_axis_type.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/invalid_channels_color.json
+++ b/tests/attributes/spec/invalid/image/invalid_channels_color.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/invalid_channels_window.json
+++ b/tests/attributes/spec/invalid/image/invalid_channels_window.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/invalid_multiscale_transform_input.json
+++ b/tests/attributes/spec/invalid/image/invalid_multiscale_transform_input.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/invalid_multiscale_transform_input_output.json
+++ b/tests/attributes/spec/invalid/image/invalid_multiscale_transform_input_output.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/invalid_multiscale_transform_output.json
+++ b/tests/attributes/spec/invalid/image/invalid_multiscale_transform_output.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/invalid_multiscales_transformations.json
+++ b/tests/attributes/spec/invalid/image/invalid_multiscales_transformations.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/invalid_path.json
+++ b/tests/attributes/spec/invalid/image/invalid_path.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/invalid_transformation_type.json
+++ b/tests/attributes/spec/invalid/image/invalid_transformation_type.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/missing_axes_name.json
+++ b/tests/attributes/spec/invalid/image/missing_axes_name.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/missing_coordinate_system_axes.json
+++ b/tests/attributes/spec/invalid/image/missing_coordinate_system_axes.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/missing_coordinate_system_name.json
+++ b/tests/attributes/spec/invalid/image/missing_coordinate_system_name.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/missing_coordinate_systems.json
+++ b/tests/attributes/spec/invalid/image/missing_coordinate_systems.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "datasets": [

--- a/tests/attributes/spec/invalid/image/missing_datasets.json
+++ b/tests/attributes/spec/invalid/image/missing_datasets.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/missing_path.json
+++ b/tests/attributes/spec/invalid/image/missing_path.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/missing_scale.json
+++ b/tests/attributes/spec/invalid/image/missing_scale.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/missing_space_axes.json
+++ b/tests/attributes/spec/invalid/image/missing_space_axes.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/missing_transformations.json
+++ b/tests/attributes/spec/invalid/image/missing_transformations.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/no_axes.json
+++ b/tests/attributes/spec/invalid/image/no_axes.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "axes": [],

--- a/tests/attributes/spec/invalid/image/no_datasets.json
+++ b/tests/attributes/spec/invalid/image/no_datasets.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/no_multiscales.json
+++ b/tests/attributes/spec/invalid/image/no_multiscales.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": []
   },
   "_conformance": {

--- a/tests/attributes/spec/invalid/image/one_space_axes.json
+++ b/tests/attributes/spec/invalid/image/one_space_axes.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/too_many_axes.json
+++ b/tests/attributes/spec/invalid/image/too_many_axes.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/image/too_many_space_axes.json
+++ b/tests/attributes/spec/invalid/image/too_many_space_axes.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev42",
+    "version": "0.6rc02",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/invalid/label/colors_duplicate.json
+++ b/tests/attributes/spec/invalid/label/colors_duplicate.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "image-label": {
       "colors": [
         {

--- a/tests/attributes/spec/invalid/label/colors_no_label_value.json
+++ b/tests/attributes/spec/invalid/label/colors_no_label_value.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "image-label": {
       "colors": [
         {

--- a/tests/attributes/spec/invalid/label/colors_rgba_length.json
+++ b/tests/attributes/spec/invalid/label/colors_rgba_length.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "image-label": {
       "colors": [
         {

--- a/tests/attributes/spec/invalid/label/colors_rgba_type.json
+++ b/tests/attributes/spec/invalid/label/colors_rgba_type.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "image-label": {
       "colors": [
         {

--- a/tests/attributes/spec/invalid/label/empty_colors.json
+++ b/tests/attributes/spec/invalid/label/empty_colors.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "image-label": {
       "colors": []
     }

--- a/tests/attributes/spec/invalid/label/empty_properties.json
+++ b/tests/attributes/spec/invalid/label/empty_properties.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "image-label": {
       "properties": []
     }

--- a/tests/attributes/spec/invalid/label/properties_no_label_value.json
+++ b/tests/attributes/spec/invalid/label/properties_no_label_value.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "image-label": {
       "properties": [
         {

--- a/tests/attributes/spec/invalid/plate/acquisition_negative_starttime.json
+++ b/tests/attributes/spec/invalid/plate/acquisition_negative_starttime.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "acquisitions": [
         {

--- a/tests/attributes/spec/invalid/plate/acquisition_noninteger_endtime.json
+++ b/tests/attributes/spec/invalid/plate/acquisition_noninteger_endtime.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "acquisitions": [
         {

--- a/tests/attributes/spec/invalid/plate/acquisition_noninteger_starttime.json
+++ b/tests/attributes/spec/invalid/plate/acquisition_noninteger_starttime.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "acquisitions": [
         {

--- a/tests/attributes/spec/invalid/plate/acquisition_zero_maximumfieldcount.json
+++ b/tests/attributes/spec/invalid/plate/acquisition_zero_maximumfieldcount.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "acquisitions": [
         {

--- a/tests/attributes/spec/invalid/plate/duplicate_columns.json
+++ b/tests/attributes/spec/invalid/plate/duplicate_columns.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "columns": [
         {

--- a/tests/attributes/spec/invalid/plate/duplicate_rows-2.json
+++ b/tests/attributes/spec/invalid/plate/duplicate_rows-2.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "columns": [
         {

--- a/tests/attributes/spec/invalid/plate/duplicate_rows.json
+++ b/tests/attributes/spec/invalid/plate/duplicate_rows.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "columns": [
         {

--- a/tests/attributes/spec/invalid/plate/empty_columns.json
+++ b/tests/attributes/spec/invalid/plate/empty_columns.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "columns": [],
       "rows": [

--- a/tests/attributes/spec/invalid/plate/empty_rows.json
+++ b/tests/attributes/spec/invalid/plate/empty_rows.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "columns": [
         {

--- a/tests/attributes/spec/invalid/plate/empty_wells.json
+++ b/tests/attributes/spec/invalid/plate/empty_wells.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "columns": [
         {

--- a/tests/attributes/spec/invalid/plate/missing_acquisition_id.json
+++ b/tests/attributes/spec/invalid/plate/missing_acquisition_id.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "acquisitions": [
         {

--- a/tests/attributes/spec/invalid/plate/missing_column_name.json
+++ b/tests/attributes/spec/invalid/plate/missing_column_name.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "columns": [
         {

--- a/tests/attributes/spec/invalid/plate/missing_columns.json
+++ b/tests/attributes/spec/invalid/plate/missing_columns.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "rows": [
         {

--- a/tests/attributes/spec/invalid/plate/missing_row_name.json
+++ b/tests/attributes/spec/invalid/plate/missing_row_name.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "columns": [
         {

--- a/tests/attributes/spec/invalid/plate/missing_rows.json
+++ b/tests/attributes/spec/invalid/plate/missing_rows.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "columns": [
         {

--- a/tests/attributes/spec/invalid/plate/missing_well_columnIndex.json
+++ b/tests/attributes/spec/invalid/plate/missing_well_columnIndex.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "columns": [
         {

--- a/tests/attributes/spec/invalid/plate/missing_well_path.json
+++ b/tests/attributes/spec/invalid/plate/missing_well_path.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "columns": [
         {

--- a/tests/attributes/spec/invalid/plate/missing_well_rowIndex.json
+++ b/tests/attributes/spec/invalid/plate/missing_well_rowIndex.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "columns": [
         {

--- a/tests/attributes/spec/invalid/plate/missing_wells.json
+++ b/tests/attributes/spec/invalid/plate/missing_wells.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "columns": [
         {

--- a/tests/attributes/spec/invalid/plate/negative_acquisition_id.json
+++ b/tests/attributes/spec/invalid/plate/negative_acquisition_id.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "acquisitions": [
         {

--- a/tests/attributes/spec/invalid/plate/negative_endtime.json
+++ b/tests/attributes/spec/invalid/plate/negative_endtime.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "acquisitions": [
         {

--- a/tests/attributes/spec/invalid/plate/non_alphanumeric_column.json
+++ b/tests/attributes/spec/invalid/plate/non_alphanumeric_column.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "columns": [
         {

--- a/tests/attributes/spec/invalid/plate/non_integer_acquisition_id.json
+++ b/tests/attributes/spec/invalid/plate/non_integer_acquisition_id.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "acquisitions": [
         {

--- a/tests/attributes/spec/invalid/plate/non_integer_acquisition_maximumfieldcount.json
+++ b/tests/attributes/spec/invalid/plate/non_integer_acquisition_maximumfieldcount.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "acquisitions": [
         {

--- a/tests/attributes/spec/invalid/plate/well_1group.json
+++ b/tests/attributes/spec/invalid/plate/well_1group.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "columns": [
         {

--- a/tests/attributes/spec/invalid/plate/well_3groups.json
+++ b/tests/attributes/spec/invalid/plate/well_3groups.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "columns": [
         {

--- a/tests/attributes/spec/invalid/plate/zero_field_count.json
+++ b/tests/attributes/spec/invalid/plate/zero_field_count.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "columns": [
         {

--- a/tests/attributes/spec/invalid/scene/scene_bijection_forward_missing_params.json
+++ b/tests/attributes/spec/invalid/scene/scene_bijection_forward_missing_params.json
@@ -1,6 +1,6 @@
 {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "scene": {
         "coordinateSystems": [
           {

--- a/tests/attributes/spec/invalid/scene/scene_bijection_inverse_missing_params.json
+++ b/tests/attributes/spec/invalid/scene/scene_bijection_inverse_missing_params.json
@@ -1,6 +1,6 @@
 {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "scene": {
         "coordinateSystems": [
           {

--- a/tests/attributes/spec/invalid/scene/scene_input_output_not_object.json
+++ b/tests/attributes/spec/invalid/scene/scene_input_output_not_object.json
@@ -1,6 +1,6 @@
 {
     "ome": {
-        "version": "0.6.dev4",
+        "version": "0.6rc0",
         "scene": {
             "coordinateTransformations": [
             {

--- a/tests/attributes/spec/invalid/scene/scene_missing_scene.json
+++ b/tests/attributes/spec/invalid/scene/scene_missing_scene.json
@@ -1,6 +1,6 @@
 {
     "ome": {
-        "version": "0.6.dev4",
+        "version": "0.6rc0",
         "coordinateSystems": [
             {
                 "name": "world",

--- a/tests/attributes/spec/invalid/scene/scene_missing_transformations.json
+++ b/tests/attributes/spec/invalid/scene/scene_missing_transformations.json
@@ -1,6 +1,6 @@
 {
     "ome": {
-        "version": "0.6.dev4",
+        "version": "0.6rc0",
         "scene": {
             "coordinateSystems": [
             {

--- a/tests/attributes/spec/invalid/transforms/bad_affine_no_affine.json
+++ b/tests/attributes/spec/invalid/transforms/bad_affine_no_affine.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/bad_affine_no_input_output.json
+++ b/tests/attributes/spec/invalid/transforms/bad_affine_no_input_output.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/bad_byDimension_no_input_output_axes.json
+++ b/tests/attributes/spec/invalid/transforms/bad_byDimension_no_input_output_axes.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/bad_byDimension_wrong axes_type.json
+++ b/tests/attributes/spec/invalid/transforms/bad_byDimension_wrong axes_type.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/bad_mapaxis.json
+++ b/tests/attributes/spec/invalid/transforms/bad_mapaxis.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/bad_mapaxis2.json
+++ b/tests/attributes/spec/invalid/transforms/bad_mapaxis2.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/bad_mapaxis3.json
+++ b/tests/attributes/spec/invalid/transforms/bad_mapaxis3.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/bad_mapaxis4.json
+++ b/tests/attributes/spec/invalid/transforms/bad_mapaxis4.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/bad_mapaxis5.json
+++ b/tests/attributes/spec/invalid/transforms/bad_mapaxis5.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/bad_projectAxis_insert_non_unique.json
+++ b/tests/attributes/spec/invalid/transforms/bad_projectAxis_insert_non_unique.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/bad_projectAxis_insert_too_high_dim.json
+++ b/tests/attributes/spec/invalid/transforms/bad_projectAxis_insert_too_high_dim.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/bad_projectAxis_insert_too_many.json
+++ b/tests/attributes/spec/invalid/transforms/bad_projectAxis_insert_too_many.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/bad_projectAxis_missing_op.json
+++ b/tests/attributes/spec/invalid/transforms/bad_projectAxis_missing_op.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/bad_projectAxis_remove_non_unique.json
+++ b/tests/attributes/spec/invalid/transforms/bad_projectAxis_remove_non_unique.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/bad_projectAxis_remove_too_high_dim.json
+++ b/tests/attributes/spec/invalid/transforms/bad_projectAxis_remove_too_high_dim.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/bad_projectAxis_remove_too_many.json
+++ b/tests/attributes/spec/invalid/transforms/bad_projectAxis_remove_too_many.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/bad_rotation.json
+++ b/tests/attributes/spec/invalid/transforms/bad_rotation.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/bad_rotation2.json
+++ b/tests/attributes/spec/invalid/transforms/bad_rotation2.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/bad_rotation3.json
+++ b/tests/attributes/spec/invalid/transforms/bad_rotation3.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/bad_scale_path_not_allowed.json
+++ b/tests/attributes/spec/invalid/transforms/bad_scale_path_not_allowed.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/bad_translate_path_not_allowed.json
+++ b/tests/attributes/spec/invalid/transforms/bad_translate_path_not_allowed.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/multiscales_transform_forbidden.json
+++ b/tests/attributes/spec/invalid/transforms/multiscales_transform_forbidden.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/multiscales_transform_forbidden2.json
+++ b/tests/attributes/spec/invalid/transforms/multiscales_transform_forbidden2.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/multiscales_transform_forbidden3.json
+++ b/tests/attributes/spec/invalid/transforms/multiscales_transform_forbidden3.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/multiscales_transform_missing_params.json
+++ b/tests/attributes/spec/invalid/transforms/multiscales_transform_missing_params.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/multiscales_transform_no_input_output.json
+++ b/tests/attributes/spec/invalid/transforms/multiscales_transform_no_input_output.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/invalid/transforms/multiscales_transform_no_input_output2.json
+++ b/tests/attributes/spec/invalid/transforms/multiscales_transform_no_input_output2.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/invalid/well/forbidden_path_1.json
+++ b/tests/attributes/spec/invalid/well/forbidden_path_1.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "well": {
       "images": [
         {

--- a/tests/attributes/spec/invalid/well/forbidden_path_2.json
+++ b/tests/attributes/spec/invalid/well/forbidden_path_2.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "well": {
       "images": [
         {

--- a/tests/attributes/spec/invalid/well/forbidden_path_3.json
+++ b/tests/attributes/spec/invalid/well/forbidden_path_3.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "well": {
       "images": [
         {

--- a/tests/attributes/spec/invalid/well/forbidden_path_4.json
+++ b/tests/attributes/spec/invalid/well/forbidden_path_4.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "well": {
       "images": [
         {

--- a/tests/attributes/spec/valid/image/custom_type_axes.json
+++ b/tests/attributes/spec/valid/image/custom_type_axes.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/valid/image/invalid_axis_units.json
+++ b/tests/attributes/spec/valid/image/invalid_axis_units.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/valid/image/mismatch_axes_units.json
+++ b/tests/attributes/spec/valid/image/mismatch_axes_units.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/valid/image/missing_name.json
+++ b/tests/attributes/spec/valid/image/missing_name.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "datasets": [

--- a/tests/attributes/spec/valid/image/multiscales_transform_additional_transforms.json
+++ b/tests/attributes/spec/valid/image/multiscales_transform_additional_transforms.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/valid/image/multiscales_transform_additional_transforms_path.json
+++ b/tests/attributes/spec/valid/image/multiscales_transform_additional_transforms_path.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/valid/image/multiscales_transform_identity.json
+++ b/tests/attributes/spec/valid/image/multiscales_transform_identity.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/valid/image/multiscales_transform_sequence.json
+++ b/tests/attributes/spec/valid/image/multiscales_transform_sequence.json
@@ -1,6 +1,6 @@
 {
 	"ome": {
-		"version": "0.6.dev4",
+		"version": "0.6rc0",
 		"multiscales": [
 			{
 				"name": "multiscales",

--- a/tests/attributes/spec/valid/image/untyped_axes.json
+++ b/tests/attributes/spec/valid/image/untyped_axes.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/spec/valid/label/minimal.json
+++ b/tests/attributes/spec/valid/label/minimal.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "image-label": {
       "colors": [
         {

--- a/tests/attributes/spec/valid/label/minimal_properties.json
+++ b/tests/attributes/spec/valid/label/minimal_properties.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "image-label": {
       "colors": [
         {

--- a/tests/attributes/spec/valid/plate/minimal_acquisitions.json
+++ b/tests/attributes/spec/valid/plate/minimal_acquisitions.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "acquisitions": [
         {

--- a/tests/attributes/spec/valid/plate/minimal_no_acquisitions.json
+++ b/tests/attributes/spec/valid/plate/minimal_no_acquisitions.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "columns": [
         {

--- a/tests/attributes/spec/valid/plate/non_alphanumeric_row.json
+++ b/tests/attributes/spec/valid/plate/non_alphanumeric_row.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "columns": [
         {

--- a/tests/attributes/spec/valid/scene/scene.json
+++ b/tests/attributes/spec/valid/scene/scene.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "scene": {
       "coordinateTransformations": [
         {

--- a/tests/attributes/spec/valid/scene/tile_stitching.json
+++ b/tests/attributes/spec/valid/scene/tile_stitching.json
@@ -1,6 +1,6 @@
 {
     "ome": {
-        "version": "0.6.dev4",
+        "version": "0.6rc0",
         "scene":{
             "coordinateTransformations": [
             {

--- a/tests/attributes/spec/valid/transforms/affine.json
+++ b/tests/attributes/spec/valid/transforms/affine.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "name": "multiscales",

--- a/tests/attributes/spec/valid/transforms/affineParams.json
+++ b/tests/attributes/spec/valid/transforms/affineParams.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "name": "multiscales",

--- a/tests/attributes/spec/valid/transforms/byDimension.json
+++ b/tests/attributes/spec/valid/transforms/byDimension.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "name": "multiscales",

--- a/tests/attributes/spec/valid/transforms/identity.json
+++ b/tests/attributes/spec/valid/transforms/identity.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "name": "multiscales",

--- a/tests/attributes/spec/valid/transforms/mapAxis.json
+++ b/tests/attributes/spec/valid/transforms/mapAxis.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "name": "multiscales",

--- a/tests/attributes/spec/valid/transforms/projectAxis.json
+++ b/tests/attributes/spec/valid/transforms/projectAxis.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "name": "multiscales",

--- a/tests/attributes/spec/valid/transforms/projectAxis2.json
+++ b/tests/attributes/spec/valid/transforms/projectAxis2.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "name": "multiscales",

--- a/tests/attributes/spec/valid/transforms/rotation.json
+++ b/tests/attributes/spec/valid/transforms/rotation.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "name": "multiscales",

--- a/tests/attributes/spec/valid/transforms/scale.json
+++ b/tests/attributes/spec/valid/transforms/scale.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "name": "multiscales",

--- a/tests/attributes/spec/valid/well/minimal_acquisitions.json
+++ b/tests/attributes/spec/valid/well/minimal_acquisitions.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "well": {
       "images": [
         {

--- a/tests/attributes/spec/valid/well/minimal_no_acquisition.json
+++ b/tests/attributes/spec/valid/well/minimal_no_acquisition.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "well": {
       "images": [
         {

--- a/tests/attributes/spec/valid/well/minimal_path_special_char.json
+++ b/tests/attributes/spec/valid/well/minimal_path_special_char.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "well": {
       "images": [
         {

--- a/tests/attributes/strict/invalid/label/no_colors.json
+++ b/tests/attributes/strict/invalid/label/no_colors.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "image-label": {}
   },
   "_conformance": {

--- a/tests/attributes/strict/invalid/plate/missing_acquisition_maximumfieldcount.json
+++ b/tests/attributes/strict/invalid/plate/missing_acquisition_maximumfieldcount.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev42",
+    "version": "0.6rc02",
     "plate": {
       "acquisitions": [
         {

--- a/tests/attributes/strict/invalid/plate/missing_acquisition_name.json
+++ b/tests/attributes/strict/invalid/plate/missing_acquisition_name.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "acquisitions": [
         {

--- a/tests/attributes/strict/invalid/plate/missing_name.json
+++ b/tests/attributes/strict/invalid/plate/missing_name.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev42",
+    "version": "0.6rc02",
     "plate": {
       "columns": [
         {

--- a/tests/attributes/strict/valid/image/image.json
+++ b/tests/attributes/strict/valid/image/image.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/strict/valid/image/image_metadata.json
+++ b/tests/attributes/strict/valid/image/image_metadata.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "@id": "top",
     "@type": "ngff:Image",
     "multiscales": [

--- a/tests/attributes/strict/valid/image/image_omero.json
+++ b/tests/attributes/strict/valid/image/image_omero.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [
@@ -155,7 +155,7 @@
         "defaultZ": 2,
         "model": "color"
       },
-      "version": "0.6.dev4"
+      "version": "0.6rc0"
     }
   },
   "_conformance": {

--- a/tests/attributes/strict/valid/image/multiscales_example.json
+++ b/tests/attributes/strict/valid/image/multiscales_example.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "name": "example",

--- a/tests/attributes/strict/valid/image/multiscales_transformations.json
+++ b/tests/attributes/strict/valid/image/multiscales_transformations.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "multiscales": [
       {
         "coordinateSystems": [

--- a/tests/attributes/strict/valid/plate/strict_acquisitions.json
+++ b/tests/attributes/strict/valid/plate/strict_acquisitions.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "acquisitions": [
         {

--- a/tests/attributes/strict/valid/plate/strict_no_acquisitions.json
+++ b/tests/attributes/strict/valid/plate/strict_no_acquisitions.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "plate": {
       "columns": [
         {

--- a/tests/attributes/strict/valid/well/strict_acquisitions.json
+++ b/tests/attributes/strict/valid/well/strict_acquisitions.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "well": {
       "images": [
         {

--- a/tests/attributes/strict/valid/well/strict_no_acquisitions.json
+++ b/tests/attributes/strict/valid/well/strict_no_acquisitions.json
@@ -1,6 +1,6 @@
 {
   "ome": {
-    "version": "0.6.dev4",
+    "version": "0.6rc0",
     "well": {
       "images": [
         {

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -21,10 +21,10 @@ for schema_filename in glob.glob("schemas/*"):
             schema_store[schema["$id"]] = schema
 
 GENERIC_SCHEMA = schema_store[
-    "https://ngff.openmicroscopy.org/0.6.dev4/schemas/ome_zarr.schema"
+    "https://ngff.openmicroscopy.org/0.6rc0/schemas/ome_zarr.schema"
 ]
 GENERIC_STRICT_SCHEMA = schema_store[
-    "https://ngff.openmicroscopy.org/0.6.dev4/schemas/strict_ome_zarr.schema"
+    "https://ngff.openmicroscopy.org/0.6rc0/schemas/strict_ome_zarr.schema"
 ]
 
 

--- a/tests/zarr/spec/invalid/image/duplicate_axes.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/image/duplicate_axes.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/invalid/image/duplicate_scale.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/image/duplicate_scale.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/invalid/image/empty_transformations.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/image/empty_transformations.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/invalid/image/invalid_axes_count.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/image/invalid_axes_count.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/invalid/image/invalid_axis_type.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/image/invalid_axis_type.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/invalid/image/invalid_channels_color.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/image/invalid_channels_color.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/invalid/image/invalid_channels_window.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/image/invalid_channels_window.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/invalid/image/invalid_multiscales_transformations.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/image/invalid_multiscales_transformations.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/invalid/image/invalid_path.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/image/invalid_path.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/invalid/image/invalid_transformation_type.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/image/invalid_transformation_type.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/invalid/image/missing_axes.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/image/missing_axes.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "datasets": [

--- a/tests/zarr/spec/invalid/image/missing_axes_name.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/image/missing_axes_name.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/invalid/image/missing_datasets.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/image/missing_datasets.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/invalid/image/missing_path.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/image/missing_path.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/invalid/image/missing_scale.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/image/missing_scale.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/invalid/image/missing_space_axes.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/image/missing_space_axes.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/invalid/image/missing_transformations.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/image/missing_transformations.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/invalid/image/no_axes.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/image/no_axes.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "axes": [],

--- a/tests/zarr/spec/invalid/image/no_datasets.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/image/no_datasets.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/invalid/image/no_multiscales.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/image/no_multiscales.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": []
     },
     "_conformance": {

--- a/tests/zarr/spec/invalid/image/one_space_axes.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/image/one_space_axes.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/invalid/image/too_many_axes.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/image/too_many_axes.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/invalid/image/too_many_space_axes.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/image/too_many_space_axes.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/invalid/label/colors_duplicate.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/label/colors_duplicate.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "image-label": {
         "colors": [
           {

--- a/tests/zarr/spec/invalid/label/colors_no_label_value.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/label/colors_no_label_value.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "image-label": {
         "colors": [
           {

--- a/tests/zarr/spec/invalid/label/colors_rgba_length.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/label/colors_rgba_length.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0
       "image-label": {
         "colors": [
           {

--- a/tests/zarr/spec/invalid/label/colors_rgba_type.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/label/colors_rgba_type.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "image-label": {
         "colors": [
           {

--- a/tests/zarr/spec/invalid/label/empty_colors.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/label/empty_colors.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "image-label": {
         "colors": []
       }

--- a/tests/zarr/spec/invalid/label/empty_properties.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/label/empty_properties.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "image-label": {
         "properties": []
       }

--- a/tests/zarr/spec/invalid/label/properties_no_label_value.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/label/properties_no_label_value.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "image-label": {
         "properties": [
           {

--- a/tests/zarr/spec/invalid/plate/acquisition_negative_starttime.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/acquisition_negative_starttime.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "acquisitions": [
           {

--- a/tests/zarr/spec/invalid/plate/acquisition_noninteger_endtime.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/acquisition_noninteger_endtime.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "acquisitions": [
           {

--- a/tests/zarr/spec/invalid/plate/acquisition_noninteger_starttime.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/acquisition_noninteger_starttime.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "acquisitions": [
           {

--- a/tests/zarr/spec/invalid/plate/acquisition_zero_maximumfieldcount.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/acquisition_zero_maximumfieldcount.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "acquisitions": [
           {

--- a/tests/zarr/spec/invalid/plate/duplicate_columns.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/duplicate_columns.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "columns": [
           {

--- a/tests/zarr/spec/invalid/plate/duplicate_rows-2.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/duplicate_rows-2.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "columns": [
           {

--- a/tests/zarr/spec/invalid/plate/duplicate_rows.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/duplicate_rows.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "columns": [
           {

--- a/tests/zarr/spec/invalid/plate/empty_columns.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/empty_columns.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "columns": [],
         "rows": [

--- a/tests/zarr/spec/invalid/plate/empty_rows.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/empty_rows.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "columns": [
           {

--- a/tests/zarr/spec/invalid/plate/empty_wells.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/empty_wells.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "columns": [
           {

--- a/tests/zarr/spec/invalid/plate/missing_acquisition_id.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/missing_acquisition_id.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "acquisitions": [
           {

--- a/tests/zarr/spec/invalid/plate/missing_column_name.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/missing_column_name.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "columns": [
           {

--- a/tests/zarr/spec/invalid/plate/missing_columns.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/missing_columns.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "rows": [
           {

--- a/tests/zarr/spec/invalid/plate/missing_row_name.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/missing_row_name.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "columns": [
           {

--- a/tests/zarr/spec/invalid/plate/missing_rows.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/missing_rows.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "columns": [
           {

--- a/tests/zarr/spec/invalid/plate/missing_well_columnIndex.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/missing_well_columnIndex.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "columns": [
           {

--- a/tests/zarr/spec/invalid/plate/missing_well_path.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/missing_well_path.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "columns": [
           {

--- a/tests/zarr/spec/invalid/plate/missing_well_rowIndex.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/missing_well_rowIndex.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "columns": [
           {

--- a/tests/zarr/spec/invalid/plate/missing_wells.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/missing_wells.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "columns": [
           {

--- a/tests/zarr/spec/invalid/plate/negative_acquisition_id.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/negative_acquisition_id.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "acquisitions": [
           {

--- a/tests/zarr/spec/invalid/plate/negative_endtime.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/negative_endtime.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "acquisitions": [
           {

--- a/tests/zarr/spec/invalid/plate/non_alphanumeric_column.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/non_alphanumeric_column.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "columns": [
           {

--- a/tests/zarr/spec/invalid/plate/non_integer_acquisition_id.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/non_integer_acquisition_id.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "acquisitions": [
           {

--- a/tests/zarr/spec/invalid/plate/non_integer_acquisition_maximumfieldcount.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/non_integer_acquisition_maximumfieldcount.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "acquisitions": [
           {

--- a/tests/zarr/spec/invalid/plate/well_1group.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/well_1group.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "columns": [
           {

--- a/tests/zarr/spec/invalid/plate/well_3groups.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/well_3groups.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "columns": [
           {

--- a/tests/zarr/spec/invalid/plate/zero_field_count.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/zero_field_count.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0
       "plate": {
         "columns": [
           {

--- a/tests/zarr/spec/valid/image/custom_type_axes.ome.zarr/zarr.json
+++ b/tests/zarr/spec/valid/image/custom_type_axes.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/valid/image/invalid_axis_units.ome.zarr/zarr.json
+++ b/tests/zarr/spec/valid/image/invalid_axis_units.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/valid/image/mismatch_axes_units.ome.zarr/zarr.json
+++ b/tests/zarr/spec/valid/image/mismatch_axes_units.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/valid/image/missing_name.ome.zarr/zarr.json
+++ b/tests/zarr/spec/valid/image/missing_name.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "datasets": [

--- a/tests/zarr/spec/valid/image/untyped_axes.ome.zarr/zarr.json
+++ b/tests/zarr/spec/valid/image/untyped_axes.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/spec/valid/label/minimal.ome.zarr/zarr.json
+++ b/tests/zarr/spec/valid/label/minimal.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "image-label": {
         "colors": [
           {

--- a/tests/zarr/spec/valid/label/minimal_properties.ome.zarr/zarr.json
+++ b/tests/zarr/spec/valid/label/minimal_properties.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "image-label": {
         "colors": [
           {

--- a/tests/zarr/spec/valid/plate/minimal_acquisitions.ome.zarr/zarr.json
+++ b/tests/zarr/spec/valid/plate/minimal_acquisitions.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "acquisitions": [
           {

--- a/tests/zarr/spec/valid/plate/minimal_no_acquisitions.ome.zarr/zarr.json
+++ b/tests/zarr/spec/valid/plate/minimal_no_acquisitions.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "columns": [
           {

--- a/tests/zarr/spec/valid/plate/non_alphanumeric_row.ome.zarr/zarr.json
+++ b/tests/zarr/spec/valid/plate/non_alphanumeric_row.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "columns": [
           {

--- a/tests/zarr/spec/valid/well/minimal_acquisitions.ome.zarr/zarr.json
+++ b/tests/zarr/spec/valid/well/minimal_acquisitions.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "well": {
         "images": [
           {

--- a/tests/zarr/spec/valid/well/minimal_no_acquisition.ome.zarr/zarr.json
+++ b/tests/zarr/spec/valid/well/minimal_no_acquisition.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "well": {
         "images": [
           {

--- a/tests/zarr/strict/invalid/label/no_colors.ome.zarr/zarr.json
+++ b/tests/zarr/strict/invalid/label/no_colors.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "image-label": {}
     },
     "_conformance": {

--- a/tests/zarr/strict/invalid/plate/missing_acquisition_maximumfieldcount.ome.zarr/zarr.json
+++ b/tests/zarr/strict/invalid/plate/missing_acquisition_maximumfieldcount.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "acquisitions": [
           {

--- a/tests/zarr/strict/invalid/plate/missing_acquisition_name.ome.zarr/zarr.json
+++ b/tests/zarr/strict/invalid/plate/missing_acquisition_name.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "acquisitions": [
           {

--- a/tests/zarr/strict/invalid/plate/missing_name.ome.zarr/zarr.json
+++ b/tests/zarr/strict/invalid/plate/missing_name.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "columns": [
           {

--- a/tests/zarr/strict/valid/image/image.ome.zarr/zarr.json
+++ b/tests/zarr/strict/valid/image/image.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/strict/valid/image/image_metadata.ome.zarr/zarr.json
+++ b/tests/zarr/strict/valid/image/image_metadata.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "@id": "top",
       "@type": "ngff:Image",
       "multiscales": [

--- a/tests/zarr/strict/valid/image/image_omero.ome.zarr/zarr.json
+++ b/tests/zarr/strict/valid/image/image_omero.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [
@@ -158,7 +158,7 @@
           "defaultZ": 2,
           "model": "color"
         },
-        "version": "0.6.dev4"
+        "version": "0.6rc0"
       }
     },
     "_conformance": {

--- a/tests/zarr/strict/valid/image/multiscales_example.ome.zarr/zarr.json
+++ b/tests/zarr/strict/valid/image/multiscales_example.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "name": "example",

--- a/tests/zarr/strict/valid/image/multiscales_transformations.ome.zarr/zarr.json
+++ b/tests/zarr/strict/valid/image/multiscales_transformations.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "multiscales": [
         {
           "coordinateSystems": [

--- a/tests/zarr/strict/valid/plate/strict_acquisitions.ome.zarr/zarr.json
+++ b/tests/zarr/strict/valid/plate/strict_acquisitions.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "acquisitions": [
           {

--- a/tests/zarr/strict/valid/plate/strict_no_acquisitions.ome.zarr/zarr.json
+++ b/tests/zarr/strict/valid/plate/strict_no_acquisitions.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "plate": {
         "columns": [
           {

--- a/tests/zarr/strict/valid/well/strict_acquisitions.ome.zarr/zarr.json
+++ b/tests/zarr/strict/valid/well/strict_acquisitions.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "well": {
         "images": [
           {

--- a/tests/zarr/strict/valid/well/strict_no_acquisitions.ome.zarr/zarr.json
+++ b/tests/zarr/strict/valid/well/strict_no_acquisitions.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev4",
+      "version": "0.6rc0",
       "well": {
         "images": [
           {

--- a/version_history.md
+++ b/version_history.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - BREAKING CHANGE: Unified `input` and `output` fields in all transformation metadata to be an object of `{"name": string, "path": string}` instead of allowing both string and object forms. This change was made to ensure consistency across all transformations and to simplify the specification.
 - BREAKING CHANGE: Replaced `arrayCoordinateSystems` with explanation of how to properly express dimensionless transforms.
+- BREAKING CHANGE: `input_axes` and `output_axes` in `byDimension` transformations are now written in camelCase (`inputAxes` and `outputAxes`) to be consistent with other transformations.
 - Displacements and coordinate transformations are now required to store the vector field as a normal multiscale group with the same metadata as other multiscales.
   Decided at EMBL Hackathon 06/2026 by RFC5 developers.
 - Additional requirements for displacement or coordinate axis `"type"` and `discrete` fields (now required).

--- a/version_history.md
+++ b/version_history.md
@@ -17,14 +17,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - New `projectAxis` transformation to add or drop dimensions explicitly.
 
 ### Changed
-- BREAKING CHANGE: Unified `input` and `output` fields in all transformation metadata to be an object of `{"name": string, "path": string}` instead of allowing both string and object forms. This change was made to ensure consistency across all transformations and to simplify the specification.
+- BREAKING CHANGE: Unified `input` and `output` fields in all transformation metadata to be an object of `{"name": string, "path": string}` instead of allowing both string and object forms.
+  This change was made to ensure consistency across all transformations and to simplify the specification.
 - BREAKING CHANGE: Replaced `arrayCoordinateSystems` with explanation of how to properly express dimensionless transforms.
-- BREAKING CHANGE: `input_axes` and `output_axes` in `byDimension` transformations are now written in camelCase (`inputAxes` and `outputAxes`) to be consistent with other transformations.
-- Displacements and coordinate transformations are now required to store the vector field as a normal multiscale group with the same metadata as other multiscales.
+- BREAKING CHANGE: `input_axes` and `output_axes` in `byDimension` transformations are now written in camelCase
+  (`inputAxes` and `outputAxes`) to be consistent with other transformations.
+- Displacements and coordinate transformations are now required to store the vector field
+  as a normal multiscale group with the same metadata as other multiscales.
   Decided at EMBL Hackathon 06/2026 by RFC5 developers.
 - Additional requirements for displacement or coordinate axis `"type"` and `discrete` fields (now required).
 - General wording improvements in the spec document for clarity and consistency.
-- Changed the `input_axes` and `output_axes` fields in the `byDimension` transform to camelCase (`inputAxes` and `outputAxes`)
 
 ### Removed
 

--- a/version_history.md
+++ b/version_history.md
@@ -33,7 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Removed `version` field from `multiscales` metadata in the image schema (`schemas/image.schema`) since it is already required at `ome > version`
 - Removed `version` field from `plate`, `well` and `labels` metadata in the spec document since it is already required at `ome > version`.
 
-## [0.6rc0] - 2026-04-22
+## [0.6.dev4] - 2026-04-22
 
 ### Changed
 

--- a/version_history.md
+++ b/version_history.md
@@ -19,7 +19,7 @@ to store the vector field as a normal multiscale group with the same metadata as
 
 - Added suggestion on which coordinate system to use for display in the spec document.
 
-## [0.6.dev4] - 2026-04-22
+## [0.6rc0] - 2026-04-22
 
 ### Changed
 

--- a/version_history.md
+++ b/version_history.md
@@ -8,16 +8,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.6 - 2026-06-24
-
-### Changed
-- Displacements and coordinate transformations are now required
-to store the vector field as a normal multiscale group with the same metadata as other multiscales. Decided at EMBL Hackathon 06/2026 by RFC5 developers.
-- Additional requirements for displacement or coordinate axis `"type"` and `discrete` fields (now required).
+## 0.6rc0 - 2026-07-01
 
 ### Added
 
+- [RFC5](https://ngff.openmicroscopy.org/rfc/5/index.html) adopted: Transformations, coordinate systems and `scene` metadata.
 - Added suggestion on which coordinate system to use for display in the spec document.
+- New `projectAxis` transformation to add or drop dimensions explicitly.
+
+### Changed
+- BREAKING CHANGE: Unified `input` and `output` fields in all transformation metadata to be an object of `{"name": string, "path": string}` instead of allowing both string and object forms. This change was made to ensure consistency across all transformations and to simplify the specification.
+- BREAKING CHANGE: Replaced `arrayCoordinateSystems` with explanation of how to properly express dimensionless transforms.
+- Displacements and coordinate transformations are now required to store the vector field as a normal multiscale group with the same metadata as other multiscales.
+  Decided at EMBL Hackathon 06/2026 by RFC5 developers.
+- Additional requirements for displacement or coordinate axis `"type"` and `discrete` fields (now required).
+- General wording improvements in the spec document for clarity and consistency.
+
+### Removed
+
+- Removed `version` field from `multiscales` metadata in the image schema (`schemas/image.schema`) since it is already required at `ome > version`
+- Removed `version` field from `plate`, `well` and `labels` metadata in the spec document since it is already required at `ome > version`.
 
 ## [0.6rc0] - 2026-04-22
 


### PR DESCRIPTION
- Updating the version numbers and version history for 0.6 (Will change to 0.6 in due time)
- Combined version history entries into single list
- Rephrased `warning` on top of document and removed 🚧 indicators