### PR TITLE
Minor: Fix array coordinates example

### DIFF
--- a/index.md
+++ b/index.md
@@ -298,9 +298,8 @@ The following conventions apply in this specification:
   the discrete coordinate system for that array defines the following array of points:
   ```
   [
-    [(0, 0), (0, 1)],
-    [(1, 0), (1, 1)],
-    [(2, 0), (3, 1)],
+    [(0, 0), (0, 1), (0, 2)],
+    [(1, 0), (1, 1), (1, 2)],
   ]
   ```
 - A "pixel"/"voxel" is the continuous region (rectangle/box) that corresponds to a single sample in the discrete array,


### PR DESCRIPTION
The example claims to show an array of shape (2, 3), but it actually shows an array of shape (3, 2) and also lists one out-of-range coordinate `(3, 1)`...

```
>>> numpy.ones((2, 3))
array([[1., 1., 1.],
       [1., 1., 1.]])
```