### PR TITLE
Fix transformations examples

### DIFF
--- a/examples/transformations/byDimensionCoordinates.json
+++ b/examples/transformations/byDimensionCoordinates.json
@@ -11,21 +11,25 @@
   ],
   "coordinateTransformations" : [
     {
-      "type" : "sequence",
+      "type" : "byDimension",
       "input" : {"name" : "in"},
       "output" : {"name" : "out"},
       "transformations" : [
         {
-            "type" : "coordinates",
-            "path" : "/coordinates",
-            "inputAxes" : ["i"],
-            "outputAxes" : ["x"]
+            "transformation" : {
+              "type" : "coordinates",
+              "path" : "/coordinates"
+            },
+            "inputAxes" : [0],
+            "outputAxes" : [0]
         },
         {
-            "type" : "scale",
-            "scale" : [2.0],
-            "inputAxes" : ["j"],
-            "outputAxes" : ["y"]
+            "transformation" : {
+              "type" : "scale",
+              "scale" : [2.0]
+            },
+            "inputAxes" : [1],
+            "outputAxes" : [1]
         }
       ]
     }

--- a/examples/transformations/byDimensionXarray.json
+++ b/examples/transformations/byDimensionXarray.json
@@ -22,14 +22,18 @@
       "output": {"name": "physical"},
       "transformations": [
         {
-          "type": "coordinates",
-          "path": "xCoordinates",
+          "transformation": {
+            "type": "coordinates",
+            "path": "xCoordinates"
+          },
           "inputAxes": [ 0 ],
           "outputAxes": [ 0 ]
         },
         {
-          "type": "coordinates",
-          "path": "yCoordinates",
+          "transformation": {
+            "type": "coordinates",
+            "path": "yCoordinates"
+          },
           "inputAxes": [ 1 ],
           "outputAxes": [ 1 ]
         }

--- a/examples/transformations/mapAxis1.json
+++ b/examples/transformations/mapAxis1.json
@@ -13,20 +13,20 @@
       "axes": [ {"name": "y", "type": "space"}, {"name": "x", "type": "space"} ]
     }
   ],
-  "coordinateTransformations": [ 
-    { 
+  "coordinateTransformations": [
+    {
       "name": "equivalent to identity",
-      "type": "mapAxis", 
+      "type": "mapAxis",
       "mapAxis": [0, 1],
-      "input": "in",
-      "output": "out1" 
+      "input": {"name": "in"},
+      "output": {"name": "out1"}
     },
-    { 
+    {
       "name": "permutation",
-      "type": "mapAxis", 
+      "type": "mapAxis",
       "mapAxis": [1, 0],
       "input": {"name": "in"},
-      "output": {"name": "out2"} 
+      "output": {"name": "out2"}
     }
   ]
 }


### PR DESCRIPTION
Found after putting https://forum.image.sc/t/ngff-weekly-dev-update-thread/110810/129?u=btbest to the test and actually running all the examples through a roundtrip test :)

Edit: Just realised fixing that sequenceSubspace example makes it almost identical to the xarrayLike example, but oh well... it has a different child type 🤷 