### PR TITLE
fix: allow 0.6 as version in 0.6rcX

### DIFF
--- a/schemas/_version.schema
+++ b/schemas/_version.schema
@@ -5,6 +5,7 @@
   "description": "OME-Zarr version.",
   "type": "string",
   "enum": [
-    "0.6rc0"
+    "0.6rc0",
+    "0.6"
   ]
 }


### PR DESCRIPTION
ome-zarr 0.6-style metadata can already be written with the 0.6 version number, because we communicated that fields will remain stable now. The schema checks for equality of the version string against `0.6rc0`, which I do not expect to be written as a version anywhere.

If it were, the schemas in this PR allow both `0.6` and `0.6rc0` as valid versions. We may want to ship this as part of an 0.6rc1 pre-release?

*edit*: If we merge https://github.com/ome/ome-ngff-validator/pull/80, then having this change on main will do the trick for now.