### PR TITLE
Fix version strings in two v0.6 zarr tests

### DIFF
--- a/tests/zarr/spec/invalid/label/colors_rgba_length.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/label/colors_rgba_length.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6rc0
+      "version": "0.6rc0",
       "image-label": {
         "colors": [
           {

--- a/tests/zarr/spec/invalid/plate/zero_field_count.ome.zarr/zarr.json
+++ b/tests/zarr/spec/invalid/plate/zero_field_count.ome.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6rc0
+      "version": "0.6rc0",
       "plate": {
         "columns": [
           {


### PR DESCRIPTION
The version string trailed off with no closing quote or comma in two of the tests. This PR fixes them!

Let me know if I've missed anything or if this was there for a reason!