### PR TITLE
fix: describe byDimension axes as indices, and a typo in image.schema

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -92,6 +92,9 @@ authors:
   - family-names: Best
     given-names: Benedikt T.
     orcid: 0000-0001-6965-1117
+  - family-names: Boussot
+    given-names: Valentin
+    orcid: 0009-0003-2465-5458
   - family-names: Comparin
     given-names: Tommaso
     orcid: 0000-0001-6853-5931

--- a/authors.yml
+++ b/authors.yml
@@ -111,6 +111,9 @@ project:
     - name: Benedikt T. Best
       github: btbest
       orcid: 0000-0001-6965-1117
+    - name: Valentin Boussot
+      github: vboussot
+      orcid: 0009-0003-2465-5458
 
     # C
     - name: Tommaso Comparin

--- a/schemas/coordinate_transformations.schema
+++ b/schemas/coordinate_transformations.schema
@@ -372,14 +372,14 @@
                 "items": {
                   "type": "number"
                 },
-                "description": "Names of the input axes for this transformation."
+                "description": "Indices of the input axes for this transformation."
               },
               "outputAxes": {
                 "type": "array",
                 "items": {
                   "type": "number"
                 },
-                "description": "Names of the output axes for this transformation."
+                "description": "Indices of the output axes for this transformation."
               }
             },
             "required": [

--- a/schemas/image.schema
+++ b/schemas/image.schema
@@ -113,7 +113,7 @@
                         ]
                       },
                       {
-                        "description": "A sequence of a ingle scale followed by a single translation",
+                        "description": "A sequence of a single scale followed by a single translation",
                         "type": "object",
                         "properties": {
                           "type": {"const": "sequence"},


### PR DESCRIPTION
Two description fixes in the schemas, against `0.9dev` as suggested in fideus-labs/ngff-zarr#686.

### `coordinate_transformations.schema`

The `byDimension` child transformations describe `inputAxes` and `outputAxes` as "Names of the ... axes", while both arrays are typed `number`. The spec text is already unambiguous that these are positions:

* the transformation table (`index.md:474`) gives `"inputAxes": List[number]` and `"outputAxes": List[number]`
* `index.md:1229`: "The values of `inputAxes` and `outputAxes` are arrays of integers."
* `index.md:1234` requires every axis index of the parent output coordinate system to appear in exactly one child `outputAxes` array
* `tests/attributes/spec/invalid/transforms/bad_byDimension_wrong axes_type.json` uses `["x"]` and `["y"]` precisely so that it is rejected

So it is the description that is out of sync, not the item type. That is #179, answered in its thread by @jo-mueller.

### `image.schema`

"A sequence of a ingle scale followed by a single translation" now reads "a single scale".

Both changes are description text only, so no document changes validity.

Noticed while vendoring the `0.9.dev1` schemas into ngff-zarr, where they are used verbatim to back `validate=True`.

Closes #179