### PR TITLE
Prepend anchors 0.6

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -97,7 +97,7 @@ project:
     - file: index.md
     - file: examples/index.md
       children:
-        - pattern: examples/**/*.md
+        - pattern: examples/*/*.md
     - file: schemas/index.md
       children:
         - pattern: schemas/*.md

--- a/pre_build.py
+++ b/pre_build.py
@@ -4,6 +4,7 @@ import glob
 from pathlib import Path
 import jsonc as json
 import logging
+from _version import __version__
 
 # Suppress warnings from json-schema-for-humans about unresolvable URLs
 logging.getLogger().setLevel(logging.ERROR)
@@ -46,7 +47,7 @@ This document contains JSON examples for {example} metadata layouts.
         for json_file in json_files:
             print(f'Processing {json_file}...')
 
-            crossref = f"examples:{example}:{Path(json_file).stem}"
+            crossref = f"{__version__}:examples:{example}:{Path(json_file).stem}"
             index_md += f"- [{Path(json_file).stem}](#{crossref})\n"
 
             json_file_name = Path(json_file).stem
@@ -113,7 +114,7 @@ Find below links to auto-generated markdown pages or interactive HTML pages for 
             # insert mySt cross-reference at top of markdown files
             with open(output_path_md, 'r', encoding='utf-8') as md_file:
                 md_content = md_file.read()
-            crossref = f"schemas:{Path(schema_file).stem}"
+            crossref = f"{__version__}:schemas:{Path(schema_file).stem}"
             md_content = f"""---
 author: ""
 ---


### PR DESCRIPTION
The anchors that are autogenerated in the `pre_build.py` script (i.e., [here](https://github.com/ome/ngff-spec/blob/cf12979769b0322ed21575889823025be350bd7f/pre_build.py#L116) on main) are generated in exactly the same way on all the other branches of ngff-spec, which leads to confusion with how anchors are resolved over at ngff (see also https://github.com/ome/ngff/pull/607)

This solves it on main, but the fix will have to be ported over to the 0.1 ... 0.5 branches, too.

Another small issue I noted - the examples section lists its own index.md as part of the examples:

<img width="486" height="338" alt="image" src="https://github.com/user-attachments/assets/e942fb22-d5fb-41d0-9366-57484c0edacb" />

Which is fixed in ee4b16806d96d4b79d4a3b9eed79c6f6abb55eb5 here, too. Big screenshot for a small fix.
